### PR TITLE
Fix HackerOne API paths, methods, and JSON:API envelope

### DIFF
--- a/assets.go
+++ b/assets.go
@@ -3,7 +3,6 @@ package hackeronecli
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -121,7 +120,7 @@ func (c *Client) GetAsset(ctx context.Context, id string) (*Asset, error) {
 }
 
 func (c *Client) CreateAsset(ctx context.Context, input CreateAssetInput) (*Asset, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("asset", input)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +138,7 @@ func (c *Client) CreateAsset(ctx context.Context, input CreateAssetInput) (*Asse
 }
 
 func (c *Client) UpdateAsset(ctx context.Context, id string, input UpdateAssetInput) (*Asset, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("asset", input)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +156,7 @@ func (c *Client) UpdateAsset(ctx context.Context, id string, input UpdateAssetIn
 }
 
 func (c *Client) ArchiveAssets(ctx context.Context, ids []string) error {
-	body, err := json.Marshal(map[string][]string{"ids": ids})
+	body, err := wrapJSONAPI("asset", map[string][]string{"ids": ids})
 	if err != nil {
 		return err
 	}
@@ -240,7 +239,7 @@ func (c *Client) ListAssetPorts(ctx context.Context, assetID string, params Page
 }
 
 func (c *Client) CreateAssetPort(ctx context.Context, assetID string, input CreatePortInput) (*Port, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("port", input)
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +304,7 @@ func (c *Client) GetScannerConfig(ctx context.Context, assetID string) (*Scanner
 }
 
 func (c *Client) UpdateScannerConfig(ctx context.Context, assetID string, input ScannerConfiguration) (*ScannerConfiguration, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("scanner-configuration", input)
 	if err != nil {
 		return nil, err
 	}
@@ -323,7 +322,7 @@ func (c *Client) UpdateScannerConfig(ctx context.Context, assetID string, input 
 }
 
 func (c *Client) AddAssetScope(ctx context.Context, input AssetScope) error {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("asset-scope", input)
 	if err != nil {
 		return err
 	}
@@ -336,7 +335,7 @@ func (c *Client) AddAssetScope(ctx context.Context, input AssetScope) error {
 }
 
 func (c *Client) UpdateAssetScope(ctx context.Context, assetID string, input AssetScope) error {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("asset-scope", input)
 	if err != nil {
 		return err
 	}
@@ -373,7 +372,7 @@ func (c *Client) ListAssetTags(ctx context.Context, params PageParams) ([]AssetT
 }
 
 func (c *Client) CreateAssetTag(ctx context.Context, input AssetTag) (*AssetTag, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("asset-tag", input)
 	if err != nil {
 		return nil, err
 	}
@@ -406,7 +405,7 @@ func (c *Client) ListAssetTagCategories(ctx context.Context, params PageParams) 
 }
 
 func (c *Client) CreateAssetTagCategory(ctx context.Context, input AssetTagCategory) (*AssetTagCategory, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("asset-tag-category", input)
 	if err != nil {
 		return nil, err
 	}

--- a/assets_test.go
+++ b/assets_test.go
@@ -74,8 +74,13 @@ func TestCreateAsset(t *testing.T) {
 		if r.URL.Path != "/assets" {
 			t.Errorf("expected path /assets, got %s", r.URL.Path)
 		}
-		var input CreateAssetInput
-		json.NewDecoder(r.Body).Decode(&input)
+		var envelope struct {
+			Data struct {
+				Attributes CreateAssetInput `json:"attributes"`
+			} `json:"data"`
+		}
+		json.NewDecoder(r.Body).Decode(&envelope)
+		input := envelope.Data.Attributes
 		if input.AssetType != "URL" {
 			t.Errorf("expected asset_type URL, got %s", input.AssetType)
 		}
@@ -125,10 +130,14 @@ func TestArchiveAssets(t *testing.T) {
 			t.Errorf("expected path /assets, got %s", r.URL.Path)
 		}
 		body, _ := io.ReadAll(r.Body)
-		var payload map[string][]string
-		json.Unmarshal(body, &payload)
-		if len(payload["ids"]) != 2 {
-			t.Errorf("expected 2 ids, got %d", len(payload["ids"]))
+		var envelope struct {
+			Data struct {
+				Attributes map[string][]string `json:"attributes"`
+			} `json:"data"`
+		}
+		json.Unmarshal(body, &envelope)
+		if len(envelope.Data.Attributes["ids"]) != 2 {
+			t.Errorf("expected 2 ids, got %d", len(envelope.Data.Attributes["ids"]))
 		}
 		w.WriteHeader(http.StatusNoContent)
 	})

--- a/client.go
+++ b/client.go
@@ -118,3 +118,21 @@ func decodeResponse(resp *http.Response, v interface{}) error {
 	defer resp.Body.Close()
 	return json.NewDecoder(resp.Body).Decode(v)
 }
+
+type jsonAPIEnvelope struct {
+	Data jsonAPIData `json:"data"`
+}
+
+type jsonAPIData struct {
+	Type       string      `json:"type"`
+	Attributes interface{} `json:"attributes"`
+}
+
+func wrapJSONAPI(resourceType string, attributes interface{}) ([]byte, error) {
+	return json.Marshal(jsonAPIEnvelope{
+		Data: jsonAPIData{
+			Type:       resourceType,
+			Attributes: attributes,
+		},
+	})
+}

--- a/credentials.go
+++ b/credentials.go
@@ -3,7 +3,6 @@ package hackeronecli
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 )
 
@@ -70,7 +69,7 @@ func (c *Client) ListCredentials(ctx context.Context, params PageParams) ([]Cred
 }
 
 func (c *Client) CreateCredential(ctx context.Context, input CreateCredentialInput) (*Credential, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("credential", input)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +87,7 @@ func (c *Client) CreateCredential(ctx context.Context, input CreateCredentialInp
 }
 
 func (c *Client) UpdateCredential(ctx context.Context, id string, input UpdateCredentialInput) (*Credential, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("credential", input)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +156,7 @@ func (c *Client) ListCredentialInquiries(ctx context.Context, programID string, 
 }
 
 func (c *Client) CreateCredentialInquiry(ctx context.Context, programID string, input CreateCredentialInquiryInput) (*CredentialInquiry, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("credential-inquiry", input)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +174,7 @@ func (c *Client) CreateCredentialInquiry(ctx context.Context, programID string, 
 }
 
 func (c *Client) UpdateCredentialInquiry(ctx context.Context, programID, inquiryID string, input CreateCredentialInquiryInput) (*CredentialInquiry, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("credential-inquiry", input)
 	if err != nil {
 		return nil, err
 	}

--- a/credentials_test.go
+++ b/credentials_test.go
@@ -50,8 +50,13 @@ func TestCreateCredential(t *testing.T) {
 			t.Errorf("expected path /credentials, got %s", r.URL.Path)
 		}
 		body, _ := io.ReadAll(r.Body)
-		var input CreateCredentialInput
-		json.Unmarshal(body, &input)
+		var envelope struct {
+			Data struct {
+				Attributes CreateCredentialInput `json:"attributes"`
+			} `json:"data"`
+		}
+		json.Unmarshal(body, &envelope)
+		input := envelope.Data.Attributes
 		if input.AccountName != "acct1" {
 			t.Errorf("expected account_name acct1, got %q", input.AccountName)
 		}

--- a/email.go
+++ b/email.go
@@ -3,7 +3,6 @@ package hackeronecli
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 )
 
 type SendEmailInput struct {
@@ -13,7 +12,7 @@ type SendEmailInput struct {
 }
 
 func (c *Client) SendEmail(ctx context.Context, input SendEmailInput) error {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("email-message", input)
 	if err != nil {
 		return err
 	}

--- a/email_test.go
+++ b/email_test.go
@@ -17,10 +17,15 @@ func TestSendEmail(t *testing.T) {
 			t.Errorf("expected path /email, got %s", r.URL.Path)
 		}
 		body, _ := io.ReadAll(r.Body)
-		var input SendEmailInput
-		if err := json.Unmarshal(body, &input); err != nil {
+		var envelope struct {
+			Data struct {
+				Attributes SendEmailInput `json:"attributes"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(body, &envelope); err != nil {
 			t.Fatalf("failed to unmarshal body: %v", err)
 		}
+		input := envelope.Data.Attributes
 		if input.To != "user@example.com" {
 			t.Errorf("expected to=user@example.com, got %q", input.To)
 		}
@@ -71,10 +76,15 @@ func TestSendEmailError(t *testing.T) {
 func TestSendEmailEmptyBody(t *testing.T) {
 	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		var input SendEmailInput
-		if err := json.Unmarshal(body, &input); err != nil {
+		var envelope struct {
+			Data struct {
+				Attributes SendEmailInput `json:"attributes"`
+			} `json:"data"`
+		}
+		if err := json.Unmarshal(body, &envelope); err != nil {
 			t.Fatalf("failed to unmarshal body: %v", err)
 		}
+		input := envelope.Data.Attributes
 		if input.Body != "" {
 			t.Errorf("expected empty body, got %q", input.Body)
 		}

--- a/internal/cmd/reports.go
+++ b/internal/cmd/reports.go
@@ -588,15 +588,15 @@ func newReportsAttachmentsCmd(clientFactory func() (*hackeronecli.Client, error)
 	uploadCmd.Flags().StringVar(&filePath, "file", "", "File path to upload")
 
 	deleteCmd := &cobra.Command{
-		Use:   "delete <id> <attachment-id>",
-		Short: "Delete an attachment from a report",
-		Args:  cobra.ExactArgs(2),
+		Use:   "delete <id>",
+		Short: "Delete attachments from a report",
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := clientFactory()
 			if err != nil {
 				return err
 			}
-			return client.DeleteAttachment(cmd.Context(), args[0], args[1])
+			return client.DeleteAttachment(cmd.Context(), args[0])
 		},
 	}
 
@@ -796,15 +796,15 @@ func newReportsRetestCmd(clientFactory func() (*hackeronecli.Client, error)) *co
 	}
 
 	cancelCmd := &cobra.Command{
-		Use:   "cancel <id> <retest-id>",
+		Use:   "cancel <id>",
 		Short: "Cancel a retest",
-		Args:  cobra.ExactArgs(2),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := clientFactory()
 			if err != nil {
 				return err
 			}
-			return client.CancelRetest(cmd.Context(), args[0], args[1])
+			return client.CancelRetest(cmd.Context(), args[0])
 		},
 	}
 

--- a/organizations.go
+++ b/organizations.go
@@ -3,7 +3,6 @@ package hackeronecli
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 )
 
@@ -193,7 +192,7 @@ func (c *Client) ListInvitations(ctx context.Context, orgID string, params PageP
 }
 
 func (c *Client) CreateInvitation(ctx context.Context, orgID string, input CreateInvitationInput) (*Invitation, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("invitation", input)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +238,7 @@ func (c *Client) GetGroup(ctx context.Context, orgID, groupID string) (*Group, e
 }
 
 func (c *Client) CreateGroup(ctx context.Context, orgID string, input CreateGroupInput) (*Group, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("group", input)
 	if err != nil {
 		return nil, err
 	}
@@ -257,7 +256,7 @@ func (c *Client) CreateGroup(ctx context.Context, orgID string, input CreateGrou
 }
 
 func (c *Client) UpdateGroup(ctx context.Context, orgID, groupID string, input UpdateGroupInput) (*Group, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("group", input)
 	if err != nil {
 		return nil, err
 	}
@@ -303,7 +302,7 @@ func (c *Client) GetMember(ctx context.Context, orgID, memberID string) (*Member
 }
 
 func (c *Client) UpdateMember(ctx context.Context, orgID, memberID string, input UpdateMemberInput) (*Member, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("organization-member", input)
 	if err != nil {
 		return nil, err
 	}

--- a/organizations_test.go
+++ b/organizations_test.go
@@ -183,8 +183,13 @@ func TestCreateInvitation(t *testing.T) {
 			t.Errorf("expected path /organizations/org-1/invitations, got %s", r.URL.Path)
 		}
 		body, _ := io.ReadAll(r.Body)
-		var input CreateInvitationInput
-		json.Unmarshal(body, &input)
+		var envelope struct {
+			Data struct {
+				Attributes CreateInvitationInput `json:"attributes"`
+			} `json:"data"`
+		}
+		json.Unmarshal(body, &envelope)
+		input := envelope.Data.Attributes
 		if input.Email != "new@example.com" {
 			t.Errorf("expected email new@example.com, got %q", input.Email)
 		}

--- a/programs.go
+++ b/programs.go
@@ -3,7 +3,6 @@ package hackeronecli
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -244,7 +243,7 @@ func (c *Client) ListReporters(ctx context.Context, programID string, params Pag
 }
 
 func (c *Client) ListTeamMembers(ctx context.Context, programID string, params PageParams) ([]TeamMember, error) {
-	resp, err := c.Get(ctx, fmt.Sprintf("/programs/%s/team_members", programID), params.Apply(nil))
+	resp, err := c.Get(ctx, fmt.Sprintf("/programs/%s/members", programID), params.Apply(nil))
 	if err != nil {
 		return nil, err
 	}
@@ -326,7 +325,7 @@ func (c *Client) NotifyExternalPlatform(ctx context.Context, programID string) (
 }
 
 func (c *Client) SendProgramMessage(ctx context.Context, programID string, input MessageInput) (map[string]interface{}, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("program-message", input)
 	if err != nil {
 		return nil, err
 	}
@@ -342,7 +341,7 @@ func (c *Client) SendProgramMessage(ctx context.Context, programID string, input
 }
 
 func (c *Client) AwardProgramBounty(ctx context.Context, programID string, input ProgramBountyInput) (map[string]interface{}, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("bounty", input)
 	if err != nil {
 		return nil, err
 	}
@@ -428,7 +427,7 @@ func (c *Client) ListCVERequests(ctx context.Context, programID string, params P
 }
 
 func (c *Client) CreateCVERequest(ctx context.Context, programID string, input CreateCVERequestInput) (*CVERequest, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("cve-request", input)
 	if err != nil {
 		return nil, err
 	}
@@ -460,7 +459,7 @@ func (c *Client) ListHackerInvitations(ctx context.Context, programID string, pa
 }
 
 func (c *Client) CreateHackerInvitation(ctx context.Context, programID string, input CreateHackerInvitationInput) (*HackerInvitation, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("hacker-invitation", input)
 	if err != nil {
 		return nil, err
 	}
@@ -478,7 +477,7 @@ func (c *Client) CreateHackerInvitation(ctx context.Context, programID string, i
 }
 
 func (c *Client) UpdatePolicy(ctx context.Context, programID string, input PolicyInput) (map[string]interface{}, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("policy", input)
 	if err != nil {
 		return nil, err
 	}
@@ -547,7 +546,7 @@ func (c *Client) ListScopes(ctx context.Context, programID string, params PagePa
 }
 
 func (c *Client) CreateScope(ctx context.Context, programID string, input CreateScopeInput) (*StructuredScope, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("structured-scope", input)
 	if err != nil {
 		return nil, err
 	}
@@ -565,7 +564,7 @@ func (c *Client) CreateScope(ctx context.Context, programID string, input Create
 }
 
 func (c *Client) UpdateProgramScope(ctx context.Context, programID, scopeID string, input UpdateScopeInput) (*StructuredScope, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("structured-scope", input)
 	if err != nil {
 		return nil, err
 	}
@@ -602,7 +601,7 @@ func (c *Client) ListAwardedSwag(ctx context.Context, programID string, params P
 }
 
 func (c *Client) UpdateAwardedSwag(ctx context.Context, programID, swagID string, input UpdateSwagInput) (*AwardedSwag, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("awarded-swag", input)
 	if err != nil {
 		return nil, err
 	}

--- a/programs_test.go
+++ b/programs_test.go
@@ -184,8 +184,8 @@ func TestListTeamMembers(t *testing.T) {
 		if r.Method != http.MethodGet {
 			t.Errorf("expected GET, got %s", r.Method)
 		}
-		if r.URL.Path != "/programs/123/team_members" {
-			t.Errorf("expected path /programs/123/team_members, got %s", r.URL.Path)
+		if r.URL.Path != "/programs/123/members" {
+			t.Errorf("expected path /programs/123/members, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"data": []map[string]interface{}{
@@ -325,8 +325,13 @@ func TestSendProgramMessage(t *testing.T) {
 			t.Errorf("expected path /programs/123/messages, got %s", r.URL.Path)
 		}
 		body, _ := io.ReadAll(r.Body)
-		var input MessageInput
-		json.Unmarshal(body, &input)
+		var envelope struct {
+			Data struct {
+				Attributes MessageInput `json:"attributes"`
+			} `json:"data"`
+		}
+		json.Unmarshal(body, &envelope)
+		input := envelope.Data.Attributes
 		if input.RecipientHandle != "hacker1" {
 			t.Errorf("expected recipient 'hacker1', got %q", input.RecipientHandle)
 		}
@@ -555,8 +560,13 @@ func TestUpdatePolicy(t *testing.T) {
 			t.Errorf("expected path /programs/123/policy, got %s", r.URL.Path)
 		}
 		body, _ := io.ReadAll(r.Body)
-		var input PolicyInput
-		json.Unmarshal(body, &input)
+		var envelope struct {
+			Data struct {
+				Attributes PolicyInput `json:"attributes"`
+			} `json:"data"`
+		}
+		json.Unmarshal(body, &envelope)
+		input := envelope.Data.Attributes
 		if input.Policy != "new policy" {
 			t.Errorf("expected policy 'new policy', got %q", input.Policy)
 		}

--- a/reports.go
+++ b/reports.go
@@ -3,7 +3,6 @@ package hackeronecli
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -109,7 +108,7 @@ func (c *Client) GetReport(ctx context.Context, id string) (*Report, error) {
 }
 
 func (c *Client) CreateReport(ctx context.Context, input CreateReportInput) (*Report, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("report", input)
 	if err != nil {
 		return nil, err
 	}
@@ -127,11 +126,11 @@ func (c *Client) CreateReport(ctx context.Context, input CreateReportInput) (*Re
 }
 
 func (c *Client) AddComment(ctx context.Context, reportID string, input CommentInput) (map[string]interface{}, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("activity-comment", input)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Post(ctx, fmt.Sprintf("/reports/%s/comments", reportID), bytes.NewReader(body))
+	resp, err := c.Post(ctx, fmt.Sprintf("/reports/%s/activities", reportID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -143,11 +142,11 @@ func (c *Client) AddComment(ctx context.Context, reportID string, input CommentI
 }
 
 func (c *Client) UpdateAssignee(ctx context.Context, reportID string, assigneeID string) (map[string]interface{}, error) {
-	body, err := json.Marshal(map[string]string{"assignee_id": assigneeID})
+	body, err := wrapJSONAPI("report-assignee", map[string]string{"assignee_id": assigneeID})
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Patch(ctx, fmt.Sprintf("/reports/%s/assignee", reportID), bytes.NewReader(body))
+	resp, err := c.Put(ctx, fmt.Sprintf("/reports/%s/assignee", reportID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +158,7 @@ func (c *Client) UpdateAssignee(ctx context.Context, reportID string, assigneeID
 }
 
 func (c *Client) CloseComments(ctx context.Context, reportID string) (map[string]interface{}, error) {
-	resp, err := c.Patch(ctx, fmt.Sprintf("/reports/%s/comments/close", reportID), bytes.NewReader([]byte("{}")))
+	resp, err := c.Put(ctx, fmt.Sprintf("/reports/%s/close_comments", reportID), bytes.NewReader([]byte("{}")))
 	if err != nil {
 		return nil, err
 	}
@@ -171,11 +170,11 @@ func (c *Client) CloseComments(ctx context.Context, reportID string) (map[string
 }
 
 func (c *Client) UpdateCustomFields(ctx context.Context, reportID string, fields map[string]interface{}) (map[string]interface{}, error) {
-	body, err := json.Marshal(fields)
+	body, err := wrapJSONAPI("custom-field-value", fields)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Patch(ctx, fmt.Sprintf("/reports/%s/custom_fields", reportID), bytes.NewReader(body))
+	resp, err := c.Post(ctx, fmt.Sprintf("/reports/%s/custom_field_values", reportID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -187,11 +186,11 @@ func (c *Client) UpdateCustomFields(ctx context.Context, reportID string, fields
 }
 
 func (c *Client) UpdateCVEs(ctx context.Context, reportID string, cves []string) (map[string]interface{}, error) {
-	body, err := json.Marshal(map[string][]string{"cves": cves})
+	body, err := wrapJSONAPI("report-cve", map[string][]string{"cves": cves})
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Patch(ctx, fmt.Sprintf("/reports/%s/cves", reportID), bytes.NewReader(body))
+	resp, err := c.Put(ctx, fmt.Sprintf("/reports/%s/cves", reportID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -203,11 +202,11 @@ func (c *Client) UpdateCVEs(ctx context.Context, reportID string, cves []string)
 }
 
 func (c *Client) UpdateInboxes(ctx context.Context, reportID string, inboxIDs []string) (map[string]interface{}, error) {
-	body, err := json.Marshal(map[string][]string{"inbox_ids": inboxIDs})
+	body, err := wrapJSONAPI("report-inbox", map[string][]string{"inbox_ids": inboxIDs})
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Patch(ctx, fmt.Sprintf("/reports/%s/inboxes", reportID), bytes.NewReader(body))
+	resp, err := c.Post(ctx, fmt.Sprintf("/reports/%s/inboxes", reportID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -219,11 +218,11 @@ func (c *Client) UpdateInboxes(ctx context.Context, reportID string, inboxIDs []
 }
 
 func (c *Client) UpdateSeverity(ctx context.Context, reportID string, input SeverityInput) (map[string]interface{}, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("severity", input)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Patch(ctx, fmt.Sprintf("/reports/%s/severity", reportID), bytes.NewReader(body))
+	resp, err := c.Post(ctx, fmt.Sprintf("/reports/%s/severities", reportID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -235,11 +234,11 @@ func (c *Client) UpdateSeverity(ctx context.Context, reportID string, input Seve
 }
 
 func (c *Client) ChangeState(ctx context.Context, reportID string, input StateChangeInput) (map[string]interface{}, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("state-change", input)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Patch(ctx, fmt.Sprintf("/reports/%s/state", reportID), bytes.NewReader(body))
+	resp, err := c.Post(ctx, fmt.Sprintf("/reports/%s/state_changes", reportID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -251,11 +250,11 @@ func (c *Client) ChangeState(ctx context.Context, reportID string, input StateCh
 }
 
 func (c *Client) UpdateReportScope(ctx context.Context, reportID string, scopeID string) (map[string]interface{}, error) {
-	body, err := json.Marshal(map[string]string{"scope_id": scopeID})
+	body, err := wrapJSONAPI("structured-scope", map[string]string{"scope_id": scopeID})
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Patch(ctx, fmt.Sprintf("/reports/%s/structured_scope", reportID), bytes.NewReader(body))
+	resp, err := c.Put(ctx, fmt.Sprintf("/reports/%s/structured_scope", reportID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -267,11 +266,11 @@ func (c *Client) UpdateReportScope(ctx context.Context, reportID string, scopeID
 }
 
 func (c *Client) UpdateTitle(ctx context.Context, reportID string, title string) (map[string]interface{}, error) {
-	body, err := json.Marshal(map[string]string{"title": title})
+	body, err := wrapJSONAPI("report-title", map[string]string{"title": title})
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Patch(ctx, fmt.Sprintf("/reports/%s/title", reportID), bytes.NewReader(body))
+	resp, err := c.Put(ctx, fmt.Sprintf("/reports/%s/title", reportID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -283,11 +282,11 @@ func (c *Client) UpdateTitle(ctx context.Context, reportID string, title string)
 }
 
 func (c *Client) UpdateWeakness(ctx context.Context, reportID string, weaknessID string) (map[string]interface{}, error) {
-	body, err := json.Marshal(map[string]string{"weakness_id": weaknessID})
+	body, err := wrapJSONAPI("weakness", map[string]string{"weakness_id": weaknessID})
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Patch(ctx, fmt.Sprintf("/reports/%s/weakness", reportID), bytes.NewReader(body))
+	resp, err := c.Put(ctx, fmt.Sprintf("/reports/%s/weakness", reportID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -299,11 +298,11 @@ func (c *Client) UpdateWeakness(ctx context.Context, reportID string, weaknessID
 }
 
 func (c *Client) UpdateReference(ctx context.Context, reportID string, reference string) (map[string]interface{}, error) {
-	body, err := json.Marshal(map[string]string{"reference": reference})
+	body, err := wrapJSONAPI("issue-tracker-reference-id", map[string]string{"reference": reference})
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Patch(ctx, fmt.Sprintf("/reports/%s/reference", reportID), bytes.NewReader(body))
+	resp, err := c.Post(ctx, fmt.Sprintf("/reports/%s/issue_tracker_reference_id", reportID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -315,7 +314,7 @@ func (c *Client) UpdateReference(ctx context.Context, reportID string, reference
 }
 
 func (c *Client) RedactReport(ctx context.Context, reportID string) (map[string]interface{}, error) {
-	resp, err := c.Patch(ctx, fmt.Sprintf("/reports/%s/redact", reportID), bytes.NewReader([]byte("{}")))
+	resp, err := c.Put(ctx, fmt.Sprintf("/reports/%s/redact", reportID), bytes.NewReader([]byte("{}")))
 	if err != nil {
 		return nil, err
 	}
@@ -327,11 +326,11 @@ func (c *Client) RedactReport(ctx context.Context, reportID string) (map[string]
 }
 
 func (c *Client) AddSummary(ctx context.Context, reportID string, content string) (map[string]interface{}, error) {
-	body, err := json.Marshal(map[string]string{"content": content})
+	body, err := wrapJSONAPI("report-summary", map[string]string{"content": content})
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Post(ctx, fmt.Sprintf("/reports/%s/summary", reportID), bytes.NewReader(body))
+	resp, err := c.Post(ctx, fmt.Sprintf("/reports/%s/summaries", reportID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -343,7 +342,7 @@ func (c *Client) AddSummary(ctx context.Context, reportID string, content string
 }
 
 func (c *Client) GeneratePDF(ctx context.Context, reportID string) (map[string]interface{}, error) {
-	resp, err := c.Post(ctx, fmt.Sprintf("/reports/%s/pdf", reportID), bytes.NewReader([]byte("{}")))
+	resp, err := c.Get(ctx, fmt.Sprintf("/reports/%s/pdf", reportID), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -355,11 +354,11 @@ func (c *Client) GeneratePDF(ctx context.Context, reportID string) (map[string]i
 }
 
 func (c *Client) TransferReport(ctx context.Context, reportID string, programID string) (map[string]interface{}, error) {
-	body, err := json.Marshal(map[string]string{"program_id": programID})
+	body, err := wrapJSONAPI("report-transfer", map[string]string{"program_id": programID})
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Post(ctx, fmt.Sprintf("/reports/%s/transfer", reportID), bytes.NewReader(body))
+	resp, err := c.Put(ctx, fmt.Sprintf("/reports/%s/transfer", reportID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -371,7 +370,7 @@ func (c *Client) TransferReport(ctx context.Context, reportID string, programID 
 }
 
 func (c *Client) EscalateReport(ctx context.Context, reportID string, integration string) (map[string]interface{}, error) {
-	body, err := json.Marshal(map[string]string{"integration": integration})
+	body, err := wrapJSONAPI("report-escalation", map[string]string{"integration": integration})
 	if err != nil {
 		return nil, err
 	}
@@ -387,12 +386,12 @@ func (c *Client) EscalateReport(ctx context.Context, reportID string, integratio
 }
 
 func (c *Client) DeescalateReport(ctx context.Context, reportID string) error {
-	_, err := c.Delete(ctx, fmt.Sprintf("/reports/%s/escalations", reportID))
+	_, err := c.Delete(ctx, fmt.Sprintf("/reports/%s/escalate", reportID))
 	return err
 }
 
 func (c *Client) AddParticipant(ctx context.Context, reportID string, email string) (map[string]interface{}, error) {
-	body, err := json.Marshal(map[string]string{"email": email})
+	body, err := wrapJSONAPI("report-participant", map[string]string{"email": email})
 	if err != nil {
 		return nil, err
 	}
@@ -425,7 +424,7 @@ func (c *Client) UploadAttachment(ctx context.Context, reportID string, filePath
 	}
 	writer.Close()
 
-	u := c.BaseURL + fmt.Sprintf("/reports/%s/attachments", reportID)
+	u := c.BaseURL + "/reports/attachments"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, &buf)
 	if err != nil {
 		return nil, err
@@ -446,13 +445,13 @@ func (c *Client) UploadAttachment(ctx context.Context, reportID string, filePath
 	return result, nil
 }
 
-func (c *Client) DeleteAttachment(ctx context.Context, reportID, attachmentID string) error {
-	_, err := c.Delete(ctx, fmt.Sprintf("/reports/%s/attachments/%s", reportID, attachmentID))
+func (c *Client) DeleteAttachment(ctx context.Context, reportID string) error {
+	_, err := c.Delete(ctx, fmt.Sprintf("/reports/%s/attachments", reportID))
 	return err
 }
 
 func (c *Client) AwardReportBounty(ctx context.Context, reportID string, input BountyInput) (map[string]interface{}, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("bounty", input)
 	if err != nil {
 		return nil, err
 	}
@@ -468,7 +467,7 @@ func (c *Client) AwardReportBounty(ctx context.Context, reportID string, input B
 }
 
 func (c *Client) MarkIneligible(ctx context.Context, reportID string) (map[string]interface{}, error) {
-	resp, err := c.Patch(ctx, fmt.Sprintf("/reports/%s/eligibility", reportID), bytes.NewReader([]byte("{}")))
+	resp, err := c.Put(ctx, fmt.Sprintf("/reports/%s/ineligible_for_bounty", reportID), bytes.NewReader([]byte("{}")))
 	if err != nil {
 		return nil, err
 	}
@@ -494,7 +493,7 @@ func (c *Client) ListBountySuggestions(ctx context.Context, reportID string, par
 }
 
 func (c *Client) CreateBountySuggestion(ctx context.Context, reportID string, input CreateBountySuggestionInput) (*BountySuggestion, error) {
-	body, err := json.Marshal(input)
+	body, err := wrapJSONAPI("bounty-suggestion", input)
 	if err != nil {
 		return nil, err
 	}
@@ -512,11 +511,11 @@ func (c *Client) CreateBountySuggestion(ctx context.Context, reportID string, in
 }
 
 func (c *Client) UpdateDisclosure(ctx context.Context, reportID string, state string) (map[string]interface{}, error) {
-	body, err := json.Marshal(map[string]string{"state": state})
+	body, err := wrapJSONAPI("disclosure-request", map[string]string{"state": state})
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Patch(ctx, fmt.Sprintf("/reports/%s/disclosure", reportID), bytes.NewReader(body))
+	resp, err := c.Post(ctx, fmt.Sprintf("/reports/%s/disclosure_requests", reportID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -528,16 +527,16 @@ func (c *Client) UpdateDisclosure(ctx context.Context, reportID string, state st
 }
 
 func (c *Client) CancelDisclosure(ctx context.Context, reportID string) error {
-	_, err := c.Delete(ctx, fmt.Sprintf("/reports/%s/disclosure", reportID))
+	_, err := c.Delete(ctx, fmt.Sprintf("/reports/%s/disclosure_requests", reportID))
 	return err
 }
 
 func (c *Client) UpdateTags(ctx context.Context, reportID string, tags []string) (map[string]interface{}, error) {
-	body, err := json.Marshal(map[string][]string{"tags": tags})
+	body, err := wrapJSONAPI("report-tag", map[string][]string{"tags": tags})
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Patch(ctx, fmt.Sprintf("/reports/%s/tags", reportID), bytes.NewReader(body))
+	resp, err := c.Put(ctx, fmt.Sprintf("/reports/%s/report_tags", reportID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -560,13 +559,13 @@ func (c *Client) RequestRetest(ctx context.Context, reportID string) (map[string
 	return result, nil
 }
 
-func (c *Client) CancelRetest(ctx context.Context, reportID, retestID string) error {
-	_, err := c.Delete(ctx, fmt.Sprintf("/reports/%s/retests/%s", reportID, retestID))
+func (c *Client) CancelRetest(ctx context.Context, reportID string) error {
+	_, err := c.Delete(ctx, fmt.Sprintf("/reports/%s/retests/cancel", reportID))
 	return err
 }
 
 func (c *Client) AwardSwag(ctx context.Context, reportID string) (map[string]interface{}, error) {
-	resp, err := c.Post(ctx, fmt.Sprintf("/reports/%s/swag", reportID), bytes.NewReader([]byte("{}")))
+	resp, err := c.Post(ctx, fmt.Sprintf("/reports/%s/swags", reportID), bytes.NewReader([]byte("{}")))
 	if err != nil {
 		return nil, err
 	}

--- a/reports_test.go
+++ b/reports_test.go
@@ -72,8 +72,13 @@ func TestCreateReport(t *testing.T) {
 			t.Errorf("expected path /reports, got %s", r.URL.Path)
 		}
 		body, _ := io.ReadAll(r.Body)
-		var input CreateReportInput
-		json.Unmarshal(body, &input)
+		var envelope struct {
+			Data struct {
+				Attributes CreateReportInput `json:"attributes"`
+			} `json:"data"`
+		}
+		json.Unmarshal(body, &envelope)
+		input := envelope.Data.Attributes
 		if input.Title != "XSS" {
 			t.Errorf("expected title 'XSS', got %q", input.Title)
 		}
@@ -100,12 +105,17 @@ func TestAddComment(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/reports/123/comments" {
-			t.Errorf("expected path /reports/123/comments, got %s", r.URL.Path)
+		if r.URL.Path != "/reports/123/activities" {
+			t.Errorf("expected path /reports/123/activities, got %s", r.URL.Path)
 		}
 		body, _ := io.ReadAll(r.Body)
-		var input CommentInput
-		json.Unmarshal(body, &input)
+		var envelope struct {
+			Data struct {
+				Attributes CommentInput `json:"attributes"`
+			} `json:"data"`
+		}
+		json.Unmarshal(body, &envelope)
+		input := envelope.Data.Attributes
 		if input.Message != "test comment" {
 			t.Errorf("expected message 'test comment', got %q", input.Message)
 		}
@@ -126,8 +136,8 @@ func TestAddComment(t *testing.T) {
 
 func TestUpdateAssignee(t *testing.T) {
 	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPatch {
-			t.Errorf("expected PATCH, got %s", r.Method)
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
 		}
 		if r.URL.Path != "/reports/123/assignee" {
 			t.Errorf("expected path /reports/123/assignee, got %s", r.URL.Path)
@@ -143,11 +153,11 @@ func TestUpdateAssignee(t *testing.T) {
 
 func TestCloseComments(t *testing.T) {
 	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPatch {
-			t.Errorf("expected PATCH, got %s", r.Method)
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
 		}
-		if r.URL.Path != "/reports/123/comments/close" {
-			t.Errorf("expected path /reports/123/comments/close, got %s", r.URL.Path)
+		if r.URL.Path != "/reports/123/close_comments" {
+			t.Errorf("expected path /reports/123/close_comments, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
 	})
@@ -160,11 +170,11 @@ func TestCloseComments(t *testing.T) {
 
 func TestUpdateCustomFields(t *testing.T) {
 	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPatch {
-			t.Errorf("expected PATCH, got %s", r.Method)
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/reports/123/custom_fields" {
-			t.Errorf("expected path /reports/123/custom_fields, got %s", r.URL.Path)
+		if r.URL.Path != "/reports/123/custom_field_values" {
+			t.Errorf("expected path /reports/123/custom_field_values, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
 	})
@@ -177,8 +187,8 @@ func TestUpdateCustomFields(t *testing.T) {
 
 func TestUpdateCVEs(t *testing.T) {
 	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPatch {
-			t.Errorf("expected PATCH, got %s", r.Method)
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
 		}
 		if r.URL.Path != "/reports/123/cves" {
 			t.Errorf("expected path /reports/123/cves, got %s", r.URL.Path)
@@ -194,8 +204,8 @@ func TestUpdateCVEs(t *testing.T) {
 
 func TestUpdateInboxes(t *testing.T) {
 	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPatch {
-			t.Errorf("expected PATCH, got %s", r.Method)
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
 		}
 		if r.URL.Path != "/reports/123/inboxes" {
 			t.Errorf("expected path /reports/123/inboxes, got %s", r.URL.Path)
@@ -211,11 +221,11 @@ func TestUpdateInboxes(t *testing.T) {
 
 func TestUpdateSeverity(t *testing.T) {
 	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPatch {
-			t.Errorf("expected PATCH, got %s", r.Method)
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/reports/123/severity" {
-			t.Errorf("expected path /reports/123/severity, got %s", r.URL.Path)
+		if r.URL.Path != "/reports/123/severities" {
+			t.Errorf("expected path /reports/123/severities, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
 	})
@@ -228,15 +238,20 @@ func TestUpdateSeverity(t *testing.T) {
 
 func TestChangeState(t *testing.T) {
 	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPatch {
-			t.Errorf("expected PATCH, got %s", r.Method)
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/reports/123/state" {
-			t.Errorf("expected path /reports/123/state, got %s", r.URL.Path)
+		if r.URL.Path != "/reports/123/state_changes" {
+			t.Errorf("expected path /reports/123/state_changes, got %s", r.URL.Path)
 		}
 		body, _ := io.ReadAll(r.Body)
-		var input StateChangeInput
-		json.Unmarshal(body, &input)
+		var envelope struct {
+			Data struct {
+				Attributes StateChangeInput `json:"attributes"`
+			} `json:"data"`
+		}
+		json.Unmarshal(body, &envelope)
+		input := envelope.Data.Attributes
 		if input.State != "triaged" {
 			t.Errorf("expected state 'triaged', got %q", input.State)
 		}
@@ -251,8 +266,8 @@ func TestChangeState(t *testing.T) {
 
 func TestUpdateReportScope(t *testing.T) {
 	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPatch {
-			t.Errorf("expected PATCH, got %s", r.Method)
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
 		}
 		if r.URL.Path != "/reports/123/structured_scope" {
 			t.Errorf("expected path /reports/123/structured_scope, got %s", r.URL.Path)
@@ -268,8 +283,8 @@ func TestUpdateReportScope(t *testing.T) {
 
 func TestUpdateTitle(t *testing.T) {
 	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPatch {
-			t.Errorf("expected PATCH, got %s", r.Method)
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
 		}
 		if r.URL.Path != "/reports/123/title" {
 			t.Errorf("expected path /reports/123/title, got %s", r.URL.Path)
@@ -285,8 +300,8 @@ func TestUpdateTitle(t *testing.T) {
 
 func TestUpdateWeakness(t *testing.T) {
 	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPatch {
-			t.Errorf("expected PATCH, got %s", r.Method)
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
 		}
 		if r.URL.Path != "/reports/123/weakness" {
 			t.Errorf("expected path /reports/123/weakness, got %s", r.URL.Path)
@@ -302,11 +317,11 @@ func TestUpdateWeakness(t *testing.T) {
 
 func TestUpdateReference(t *testing.T) {
 	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPatch {
-			t.Errorf("expected PATCH, got %s", r.Method)
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/reports/123/reference" {
-			t.Errorf("expected path /reports/123/reference, got %s", r.URL.Path)
+		if r.URL.Path != "/reports/123/issue_tracker_reference_id" {
+			t.Errorf("expected path /reports/123/issue_tracker_reference_id, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
 	})
@@ -319,8 +334,8 @@ func TestUpdateReference(t *testing.T) {
 
 func TestRedactReport(t *testing.T) {
 	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPatch {
-			t.Errorf("expected PATCH, got %s", r.Method)
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
 		}
 		if r.URL.Path != "/reports/123/redact" {
 			t.Errorf("expected path /reports/123/redact, got %s", r.URL.Path)
@@ -339,8 +354,8 @@ func TestAddSummary(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/reports/123/summary" {
-			t.Errorf("expected path /reports/123/summary, got %s", r.URL.Path)
+		if r.URL.Path != "/reports/123/summaries" {
+			t.Errorf("expected path /reports/123/summaries, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
 	})
@@ -353,8 +368,8 @@ func TestAddSummary(t *testing.T) {
 
 func TestGeneratePDF(t *testing.T) {
 	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Errorf("expected POST, got %s", r.Method)
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
 		}
 		if r.URL.Path != "/reports/123/pdf" {
 			t.Errorf("expected path /reports/123/pdf, got %s", r.URL.Path)
@@ -373,8 +388,8 @@ func TestGeneratePDF(t *testing.T) {
 
 func TestTransferReport(t *testing.T) {
 	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPost {
-			t.Errorf("expected POST, got %s", r.Method)
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
 		}
 		if r.URL.Path != "/reports/123/transfer" {
 			t.Errorf("expected path /reports/123/transfer, got %s", r.URL.Path)
@@ -410,8 +425,8 @@ func TestDeescalateReport(t *testing.T) {
 		if r.Method != http.MethodDelete {
 			t.Errorf("expected DELETE, got %s", r.Method)
 		}
-		if r.URL.Path != "/reports/123/escalations" {
-			t.Errorf("expected path /reports/123/escalations, got %s", r.URL.Path)
+		if r.URL.Path != "/reports/123/escalate" {
+			t.Errorf("expected path /reports/123/escalate, got %s", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -447,8 +462,8 @@ func TestUploadAttachment(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/reports/123/attachments" {
-			t.Errorf("expected path /reports/123/attachments, got %s", r.URL.Path)
+		if r.URL.Path != "/reports/attachments" {
+			t.Errorf("expected path /reports/attachments, got %s", r.URL.Path)
 		}
 		ct := r.Header.Get("Content-Type")
 		if !strings.HasPrefix(ct, "multipart/form-data") {
@@ -482,13 +497,13 @@ func TestDeleteAttachment(t *testing.T) {
 		if r.Method != http.MethodDelete {
 			t.Errorf("expected DELETE, got %s", r.Method)
 		}
-		if r.URL.Path != "/reports/123/attachments/att-1" {
-			t.Errorf("expected path /reports/123/attachments/att-1, got %s", r.URL.Path)
+		if r.URL.Path != "/reports/123/attachments" {
+			t.Errorf("expected path /reports/123/attachments, got %s", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := c.DeleteAttachment(context.Background(), "123", "att-1")
+	err := c.DeleteAttachment(context.Background(), "123")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -513,11 +528,11 @@ func TestAwardReportBounty(t *testing.T) {
 
 func TestMarkIneligible(t *testing.T) {
 	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPatch {
-			t.Errorf("expected PATCH, got %s", r.Method)
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
 		}
-		if r.URL.Path != "/reports/123/eligibility" {
-			t.Errorf("expected path /reports/123/eligibility, got %s", r.URL.Path)
+		if r.URL.Path != "/reports/123/ineligible_for_bounty" {
+			t.Errorf("expected path /reports/123/ineligible_for_bounty, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
 	})
@@ -577,11 +592,11 @@ func TestCreateBountySuggestion(t *testing.T) {
 
 func TestUpdateDisclosure(t *testing.T) {
 	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPatch {
-			t.Errorf("expected PATCH, got %s", r.Method)
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/reports/123/disclosure" {
-			t.Errorf("expected path /reports/123/disclosure, got %s", r.URL.Path)
+		if r.URL.Path != "/reports/123/disclosure_requests" {
+			t.Errorf("expected path /reports/123/disclosure_requests, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
 	})
@@ -597,8 +612,8 @@ func TestCancelDisclosure(t *testing.T) {
 		if r.Method != http.MethodDelete {
 			t.Errorf("expected DELETE, got %s", r.Method)
 		}
-		if r.URL.Path != "/reports/123/disclosure" {
-			t.Errorf("expected path /reports/123/disclosure, got %s", r.URL.Path)
+		if r.URL.Path != "/reports/123/disclosure_requests" {
+			t.Errorf("expected path /reports/123/disclosure_requests, got %s", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusNoContent)
 	})
@@ -611,11 +626,11 @@ func TestCancelDisclosure(t *testing.T) {
 
 func TestUpdateTags(t *testing.T) {
 	c, _ := testServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPatch {
-			t.Errorf("expected PATCH, got %s", r.Method)
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
 		}
-		if r.URL.Path != "/reports/123/tags" {
-			t.Errorf("expected path /reports/123/tags, got %s", r.URL.Path)
+		if r.URL.Path != "/reports/123/report_tags" {
+			t.Errorf("expected path /reports/123/report_tags, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
 	})
@@ -648,13 +663,13 @@ func TestCancelRetest(t *testing.T) {
 		if r.Method != http.MethodDelete {
 			t.Errorf("expected DELETE, got %s", r.Method)
 		}
-		if r.URL.Path != "/reports/123/retests/rt-1" {
-			t.Errorf("expected path /reports/123/retests/rt-1, got %s", r.URL.Path)
+		if r.URL.Path != "/reports/123/retests/cancel" {
+			t.Errorf("expected path /reports/123/retests/cancel, got %s", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := c.CancelRetest(context.Background(), "123", "rt-1")
+	err := c.CancelRetest(context.Background(), "123")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -665,8 +680,8 @@ func TestAwardSwag(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/reports/123/swag" {
-			t.Errorf("expected path /reports/123/swag, got %s", r.URL.Path)
+		if r.URL.Path != "/reports/123/swags" {
+			t.Errorf("expected path /reports/123/swags, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
 	})


### PR DESCRIPTION
## Summary
- **URL path corrections**: Fixed 15+ incorrect endpoint paths in `reports.go` and `programs.go` (e.g. `/comments`→`/activities`, `/state`→`/state_changes`, `/severity`→`/severities`, `/tags`→`/report_tags`, `/team_members`→`/members`)
- **HTTP method corrections**: Changed several endpoints from PATCH to PUT or POST to match the HackerOne API spec
- **JSON:API envelope wrapping**: All POST/PUT request bodies now use `wrapJSONAPI()` to wrap payloads in `{"data":{"type":"...","attributes":{...}}}` as required by the HackerOne Customer Resources API v1, across `reports.go`, `programs.go`, `assets.go`, `credentials.go`, `organizations.go`, and `email.go`
- **Test updates**: Updated 11 test assertions across 6 test files to unwrap the JSON:API envelope before checking field values

## Test plan
- [x] `go test ./...` passes (all tests green)
- [x] `go build ./...` compiles cleanly
- [ ] Manual verification with real HackerOne API credentials (e.g. `h1 programs list`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)