### PR TITLE
Fix /me/ prefix for top-level list endpoints

### DIFF
--- a/organizations.go
+++ b/organizations.go
@@ -94,7 +94,7 @@ type UpdateMemberInput struct {
 }
 
 func (c *Client) ListOrganizations(ctx context.Context, params PageParams) ([]Organization, error) {
-	resp, err := c.Get(ctx, "/organizations", params.Apply(nil))
+	resp, err := c.Get(ctx, "/me/organizations", params.Apply(nil))
 	if err != nil {
 		return nil, err
 	}

--- a/organizations_test.go
+++ b/organizations_test.go
@@ -13,8 +13,8 @@ func TestListOrganizations(t *testing.T) {
 		if r.Method != http.MethodGet {
 			t.Errorf("expected GET, got %s", r.Method)
 		}
-		if r.URL.Path != "/organizations" {
-			t.Errorf("expected path /organizations, got %s", r.URL.Path)
+		if r.URL.Path != "/me/organizations" {
+			t.Errorf("expected path /me/organizations, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"data": []map[string]interface{}{

--- a/programs.go
+++ b/programs.go
@@ -147,7 +147,7 @@ type PolicyInput struct {
 }
 
 func (c *Client) ListPrograms(ctx context.Context, params PageParams) ([]Program, error) {
-	resp, err := c.Get(ctx, "/programs", params.Apply(nil))
+	resp, err := c.Get(ctx, "/me/programs", params.Apply(nil))
 	if err != nil {
 		return nil, err
 	}

--- a/programs_test.go
+++ b/programs_test.go
@@ -16,8 +16,8 @@ func TestListPrograms(t *testing.T) {
 		if r.Method != http.MethodGet {
 			t.Errorf("expected GET, got %s", r.Method)
 		}
-		if r.URL.Path != "/programs" {
-			t.Errorf("expected path /programs, got %s", r.URL.Path)
+		if r.URL.Path != "/me/programs" {
+			t.Errorf("expected path /me/programs, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"data": []map[string]interface{}{


### PR DESCRIPTION
## Summary
- `ListPrograms` now calls `/me/programs` instead of `/programs`
- `ListOrganizations` now calls `/me/organizations` instead of `/organizations`
- The HackerOne API requires the `/me/` prefix for listing the authenticated user's top-level resources, while sub-resource endpoints (e.g. `/programs/{id}/members`) work without it

## Test plan
- [x] `go test ./...` passes
- [x] Verified `h1 programs list` returns data against live API (was returning 404)
- [x] Verified `h1 organizations list` returns data against live API (was returning 404)

Generated with [Claude Code](https://claude.com/claude-code)