### PR TITLE
Scope all asset endpoints under organization

### DIFF
--- a/assets.go
+++ b/assets.go
@@ -90,9 +90,13 @@ type AssetTagCategoryAttributes struct {
 	Name string `json:"name"`
 }
 
-func (c *Client) ListAssets(ctx context.Context, params PageParams) ([]Asset, error) {
+func orgAssetsPath(orgID string) string {
+	return fmt.Sprintf("/organizations/%s/assets", orgID)
+}
+
+func (c *Client) ListAssets(ctx context.Context, orgID string, params PageParams) ([]Asset, error) {
 	qp := params.Apply(nil)
-	resp, err := c.Get(ctx, "/assets", qp)
+	resp, err := c.Get(ctx, orgAssetsPath(orgID), qp)
 	if err != nil {
 		return nil, err
 	}
@@ -105,8 +109,8 @@ func (c *Client) ListAssets(ctx context.Context, params PageParams) ([]Asset, er
 	return result.Data, nil
 }
 
-func (c *Client) GetAsset(ctx context.Context, id string) (*Asset, error) {
-	resp, err := c.Get(ctx, "/assets/"+id, nil)
+func (c *Client) GetAsset(ctx context.Context, orgID, id string) (*Asset, error) {
+	resp, err := c.Get(ctx, orgAssetsPath(orgID)+"/"+id, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -119,12 +123,12 @@ func (c *Client) GetAsset(ctx context.Context, id string) (*Asset, error) {
 	return &result.Data, nil
 }
 
-func (c *Client) CreateAsset(ctx context.Context, input CreateAssetInput) (*Asset, error) {
+func (c *Client) CreateAsset(ctx context.Context, orgID string, input CreateAssetInput) (*Asset, error) {
 	body, err := wrapJSONAPI("asset", input)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Post(ctx, "/assets", bytes.NewReader(body))
+	resp, err := c.Post(ctx, orgAssetsPath(orgID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -137,12 +141,12 @@ func (c *Client) CreateAsset(ctx context.Context, input CreateAssetInput) (*Asse
 	return &result.Data, nil
 }
 
-func (c *Client) UpdateAsset(ctx context.Context, id string, input UpdateAssetInput) (*Asset, error) {
+func (c *Client) UpdateAsset(ctx context.Context, orgID, id string, input UpdateAssetInput) (*Asset, error) {
 	body, err := wrapJSONAPI("asset", input)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Put(ctx, "/assets/"+id, bytes.NewReader(body))
+	resp, err := c.Put(ctx, orgAssetsPath(orgID)+"/"+id, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -155,12 +159,12 @@ func (c *Client) UpdateAsset(ctx context.Context, id string, input UpdateAssetIn
 	return &result.Data, nil
 }
 
-func (c *Client) ArchiveAssets(ctx context.Context, ids []string) error {
+func (c *Client) ArchiveAssets(ctx context.Context, orgID string, ids []string) error {
 	body, err := wrapJSONAPI("asset", map[string][]string{"ids": ids})
 	if err != nil {
 		return err
 	}
-	req, err := c.newRequest(ctx, http.MethodDelete, "/assets", bytes.NewReader(body))
+	req, err := c.newRequest(ctx, http.MethodDelete, orgAssetsPath(orgID), bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -172,12 +176,12 @@ func (c *Client) ArchiveAssets(ctx context.Context, ids []string) error {
 	return nil
 }
 
-func (c *Client) ImportAssets(ctx context.Context, filePath string) (map[string]interface{}, error) {
+func (c *Client) ImportAssets(ctx context.Context, orgID, filePath string) (map[string]interface{}, error) {
 	body, contentType, err := createMultipartFile("file", filePath)
 	if err != nil {
 		return nil, err
 	}
-	req, err := c.newRequest(ctx, http.MethodPost, "/assets/import", body)
+	req, err := c.newRequest(ctx, http.MethodPost, orgAssetsPath(orgID)+"/import", body)
 	if err != nil {
 		return nil, err
 	}
@@ -193,8 +197,8 @@ func (c *Client) ImportAssets(ctx context.Context, filePath string) (map[string]
 	return result, nil
 }
 
-func (c *Client) GetImportStatus(ctx context.Context, id string) (map[string]interface{}, error) {
-	resp, err := c.Get(ctx, "/assets/import/"+id, nil)
+func (c *Client) GetImportStatus(ctx context.Context, orgID, id string) (map[string]interface{}, error) {
+	resp, err := c.Get(ctx, orgAssetsPath(orgID)+"/import/"+id, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -205,12 +209,12 @@ func (c *Client) GetImportStatus(ctx context.Context, id string) (map[string]int
 	return result, nil
 }
 
-func (c *Client) UploadAssetScreenshot(ctx context.Context, assetID, filePath string) error {
+func (c *Client) UploadAssetScreenshot(ctx context.Context, orgID, assetID, filePath string) error {
 	body, contentType, err := createMultipartFile("file", filePath)
 	if err != nil {
 		return err
 	}
-	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("/assets/%s/attachments", assetID), body)
+	req, err := c.newRequest(ctx, http.MethodPost, fmt.Sprintf("%s/%s/attachments", orgAssetsPath(orgID), assetID), body)
 	if err != nil {
 		return err
 	}
@@ -223,9 +227,9 @@ func (c *Client) UploadAssetScreenshot(ctx context.Context, assetID, filePath st
 	return nil
 }
 
-func (c *Client) ListAssetPorts(ctx context.Context, assetID string, params PageParams) ([]Port, error) {
+func (c *Client) ListAssetPorts(ctx context.Context, orgID, assetID string, params PageParams) ([]Port, error) {
 	qp := params.Apply(nil)
-	resp, err := c.Get(ctx, fmt.Sprintf("/assets/%s/ports", assetID), qp)
+	resp, err := c.Get(ctx, fmt.Sprintf("%s/%s/ports", orgAssetsPath(orgID), assetID), qp)
 	if err != nil {
 		return nil, err
 	}
@@ -238,12 +242,12 @@ func (c *Client) ListAssetPorts(ctx context.Context, assetID string, params Page
 	return result.Data, nil
 }
 
-func (c *Client) CreateAssetPort(ctx context.Context, assetID string, input CreatePortInput) (*Port, error) {
+func (c *Client) CreateAssetPort(ctx context.Context, orgID, assetID string, input CreatePortInput) (*Port, error) {
 	body, err := wrapJSONAPI("port", input)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Post(ctx, fmt.Sprintf("/assets/%s/ports", assetID), bytes.NewReader(body))
+	resp, err := c.Post(ctx, fmt.Sprintf("%s/%s/ports", orgAssetsPath(orgID), assetID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -256,8 +260,8 @@ func (c *Client) CreateAssetPort(ctx context.Context, assetID string, input Crea
 	return &result.Data, nil
 }
 
-func (c *Client) DeleteAssetPort(ctx context.Context, assetID, portID string) error {
-	resp, err := c.Delete(ctx, fmt.Sprintf("/assets/%s/ports/%s", assetID, portID))
+func (c *Client) DeleteAssetPort(ctx context.Context, orgID, assetID, portID string) error {
+	resp, err := c.Delete(ctx, fmt.Sprintf("%s/%s/ports/%s", orgAssetsPath(orgID), assetID, portID))
 	if err != nil {
 		return err
 	}
@@ -265,8 +269,8 @@ func (c *Client) DeleteAssetPort(ctx context.Context, assetID, portID string) er
 	return nil
 }
 
-func (c *Client) GetReachabilityStatus(ctx context.Context, assetID string) (map[string]interface{}, error) {
-	resp, err := c.Get(ctx, fmt.Sprintf("/assets/%s/reachability_status", assetID), nil)
+func (c *Client) GetReachabilityStatus(ctx context.Context, orgID, assetID string) (map[string]interface{}, error) {
+	resp, err := c.Get(ctx, fmt.Sprintf("%s/%s/reachability_status", orgAssetsPath(orgID), assetID), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -277,8 +281,8 @@ func (c *Client) GetReachabilityStatus(ctx context.Context, assetID string) (map
 	return result, nil
 }
 
-func (c *Client) CheckReachability(ctx context.Context, assetID string) (map[string]interface{}, error) {
-	resp, err := c.Post(ctx, fmt.Sprintf("/assets/%s/check_reachability", assetID), nil)
+func (c *Client) CheckReachability(ctx context.Context, orgID, assetID string) (map[string]interface{}, error) {
+	resp, err := c.Post(ctx, fmt.Sprintf("%s/%s/check_reachability", orgAssetsPath(orgID), assetID), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -289,8 +293,8 @@ func (c *Client) CheckReachability(ctx context.Context, assetID string) (map[str
 	return result, nil
 }
 
-func (c *Client) GetScannerConfig(ctx context.Context, assetID string) (*ScannerConfiguration, error) {
-	resp, err := c.Get(ctx, fmt.Sprintf("/assets/%s/scanner_configuration", assetID), nil)
+func (c *Client) GetScannerConfig(ctx context.Context, orgID, assetID string) (*ScannerConfiguration, error) {
+	resp, err := c.Get(ctx, fmt.Sprintf("%s/%s/scanner_configuration", orgAssetsPath(orgID), assetID), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -303,12 +307,12 @@ func (c *Client) GetScannerConfig(ctx context.Context, assetID string) (*Scanner
 	return &result.Data, nil
 }
 
-func (c *Client) UpdateScannerConfig(ctx context.Context, assetID string, input ScannerConfiguration) (*ScannerConfiguration, error) {
+func (c *Client) UpdateScannerConfig(ctx context.Context, orgID, assetID string, input ScannerConfiguration) (*ScannerConfiguration, error) {
 	body, err := wrapJSONAPI("scanner-configuration", input)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Put(ctx, fmt.Sprintf("/assets/%s/scanner_configuration", assetID), bytes.NewReader(body))
+	resp, err := c.Put(ctx, fmt.Sprintf("%s/%s/scanner_configuration", orgAssetsPath(orgID), assetID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -321,12 +325,12 @@ func (c *Client) UpdateScannerConfig(ctx context.Context, assetID string, input 
 	return &result.Data, nil
 }
 
-func (c *Client) AddAssetScope(ctx context.Context, input AssetScope) error {
+func (c *Client) AddAssetScope(ctx context.Context, orgID string, input AssetScope) error {
 	body, err := wrapJSONAPI("asset-scope", input)
 	if err != nil {
 		return err
 	}
-	resp, err := c.Post(ctx, "/assets/scopes", bytes.NewReader(body))
+	resp, err := c.Post(ctx, orgAssetsPath(orgID)+"/scopes", bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -334,12 +338,12 @@ func (c *Client) AddAssetScope(ctx context.Context, input AssetScope) error {
 	return nil
 }
 
-func (c *Client) UpdateAssetScope(ctx context.Context, assetID string, input AssetScope) error {
+func (c *Client) UpdateAssetScope(ctx context.Context, orgID, assetID string, input AssetScope) error {
 	body, err := wrapJSONAPI("asset-scope", input)
 	if err != nil {
 		return err
 	}
-	resp, err := c.Put(ctx, fmt.Sprintf("/assets/%s/scopes", assetID), bytes.NewReader(body))
+	resp, err := c.Put(ctx, fmt.Sprintf("%s/%s/scopes", orgAssetsPath(orgID), assetID), bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -347,8 +351,8 @@ func (c *Client) UpdateAssetScope(ctx context.Context, assetID string, input Ass
 	return nil
 }
 
-func (c *Client) ArchiveAssetScopes(ctx context.Context, assetID string) error {
-	resp, err := c.Delete(ctx, fmt.Sprintf("/assets/%s/scopes", assetID))
+func (c *Client) ArchiveAssetScopes(ctx context.Context, orgID, assetID string) error {
+	resp, err := c.Delete(ctx, fmt.Sprintf("%s/%s/scopes", orgAssetsPath(orgID), assetID))
 	if err != nil {
 		return err
 	}
@@ -356,9 +360,9 @@ func (c *Client) ArchiveAssetScopes(ctx context.Context, assetID string) error {
 	return nil
 }
 
-func (c *Client) ListAssetTags(ctx context.Context, params PageParams) ([]AssetTag, error) {
+func (c *Client) ListAssetTags(ctx context.Context, orgID string, params PageParams) ([]AssetTag, error) {
 	qp := params.Apply(nil)
-	resp, err := c.Get(ctx, "/asset_tags", qp)
+	resp, err := c.Get(ctx, fmt.Sprintf("/organizations/%s/asset_tags", orgID), qp)
 	if err != nil {
 		return nil, err
 	}
@@ -371,12 +375,12 @@ func (c *Client) ListAssetTags(ctx context.Context, params PageParams) ([]AssetT
 	return result.Data, nil
 }
 
-func (c *Client) CreateAssetTag(ctx context.Context, input AssetTag) (*AssetTag, error) {
+func (c *Client) CreateAssetTag(ctx context.Context, orgID string, input AssetTag) (*AssetTag, error) {
 	body, err := wrapJSONAPI("asset-tag", input)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Post(ctx, "/asset_tags", bytes.NewReader(body))
+	resp, err := c.Post(ctx, fmt.Sprintf("/organizations/%s/asset_tags", orgID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -389,9 +393,9 @@ func (c *Client) CreateAssetTag(ctx context.Context, input AssetTag) (*AssetTag,
 	return &result.Data, nil
 }
 
-func (c *Client) ListAssetTagCategories(ctx context.Context, params PageParams) ([]AssetTagCategory, error) {
+func (c *Client) ListAssetTagCategories(ctx context.Context, orgID string, params PageParams) ([]AssetTagCategory, error) {
 	qp := params.Apply(nil)
-	resp, err := c.Get(ctx, "/asset_tag_categories", qp)
+	resp, err := c.Get(ctx, fmt.Sprintf("/organizations/%s/asset_tag_categories", orgID), qp)
 	if err != nil {
 		return nil, err
 	}
@@ -404,12 +408,12 @@ func (c *Client) ListAssetTagCategories(ctx context.Context, params PageParams) 
 	return result.Data, nil
 }
 
-func (c *Client) CreateAssetTagCategory(ctx context.Context, input AssetTagCategory) (*AssetTagCategory, error) {
+func (c *Client) CreateAssetTagCategory(ctx context.Context, orgID string, input AssetTagCategory) (*AssetTagCategory, error) {
 	body, err := wrapJSONAPI("asset-tag-category", input)
 	if err != nil {
 		return nil, err
 	}
-	resp, err := c.Post(ctx, "/asset_tag_categories", bytes.NewReader(body))
+	resp, err := c.Post(ctx, fmt.Sprintf("/organizations/%s/asset_tag_categories", orgID), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}

--- a/assets_test.go
+++ b/assets_test.go
@@ -16,8 +16,8 @@ func TestListAssets(t *testing.T) {
 		if r.Method != http.MethodGet {
 			t.Errorf("expected GET, got %s", r.Method)
 		}
-		if r.URL.Path != "/assets" {
-			t.Errorf("expected path /assets, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/assets" {
+			t.Errorf("expected path /organizations/org1/assets, got %s", r.URL.Path)
 		}
 		if r.URL.Query().Get("page[number]") != "1" {
 			t.Errorf("expected page[number]=1, got %s", r.URL.Query().Get("page[number]"))
@@ -29,7 +29,7 @@ func TestListAssets(t *testing.T) {
 		})
 	})
 
-	assets, err := c.ListAssets(context.Background(), PageParams{Number: 1, Size: 10})
+	assets, err := c.ListAssets(context.Background(), "org1", PageParams{Number: 1, Size: 10})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -49,15 +49,15 @@ func TestGetAsset(t *testing.T) {
 		if r.Method != http.MethodGet {
 			t.Errorf("expected GET, got %s", r.Method)
 		}
-		if r.URL.Path != "/assets/a1" {
-			t.Errorf("expected path /assets/a1, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/assets/a1" {
+			t.Errorf("expected path /organizations/org1/assets/a1, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"data": Asset{ID: "a1", Type: "asset", Attributes: AssetAttributes{AssetType: "URL", Identifier: "example.com"}},
 		})
 	})
 
-	asset, err := c.GetAsset(context.Background(), "a1")
+	asset, err := c.GetAsset(context.Background(), "org1", "a1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -71,8 +71,8 @@ func TestCreateAsset(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/assets" {
-			t.Errorf("expected path /assets, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/assets" {
+			t.Errorf("expected path /organizations/org1/assets, got %s", r.URL.Path)
 		}
 		var envelope struct {
 			Data struct {
@@ -90,7 +90,7 @@ func TestCreateAsset(t *testing.T) {
 		})
 	})
 
-	asset, err := c.CreateAsset(context.Background(), CreateAssetInput{AssetType: "URL", Identifier: "test.com"})
+	asset, err := c.CreateAsset(context.Background(), "org1", CreateAssetInput{AssetType: "URL", Identifier: "test.com"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -104,15 +104,15 @@ func TestUpdateAsset(t *testing.T) {
 		if r.Method != http.MethodPut {
 			t.Errorf("expected PUT, got %s", r.Method)
 		}
-		if r.URL.Path != "/assets/a1" {
-			t.Errorf("expected path /assets/a1, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/assets/a1" {
+			t.Errorf("expected path /organizations/org1/assets/a1, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"data": Asset{ID: "a1", Type: "asset", Attributes: AssetAttributes{Description: "updated"}},
 		})
 	})
 
-	asset, err := c.UpdateAsset(context.Background(), "a1", UpdateAssetInput{Description: "updated"})
+	asset, err := c.UpdateAsset(context.Background(), "org1", "a1", UpdateAssetInput{Description: "updated"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -126,8 +126,8 @@ func TestArchiveAssets(t *testing.T) {
 		if r.Method != http.MethodDelete {
 			t.Errorf("expected DELETE, got %s", r.Method)
 		}
-		if r.URL.Path != "/assets" {
-			t.Errorf("expected path /assets, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/assets" {
+			t.Errorf("expected path /organizations/org1/assets, got %s", r.URL.Path)
 		}
 		body, _ := io.ReadAll(r.Body)
 		var envelope struct {
@@ -142,7 +142,7 @@ func TestArchiveAssets(t *testing.T) {
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := c.ArchiveAssets(context.Background(), []string{"a1", "a2"})
+	err := c.ArchiveAssets(context.Background(), "org1", []string{"a1", "a2"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -156,8 +156,8 @@ func TestImportAssets(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/assets/import" {
-			t.Errorf("expected path /assets/import, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/assets/import" {
+			t.Errorf("expected path /organizations/org1/assets/import, got %s", r.URL.Path)
 		}
 		ct := r.Header.Get("Content-Type")
 		if !strings.HasPrefix(ct, "multipart/form-data") {
@@ -166,7 +166,7 @@ func TestImportAssets(t *testing.T) {
 		json.NewEncoder(w).Encode(map[string]interface{}{"import_id": "imp1"})
 	})
 
-	result, err := c.ImportAssets(context.Background(), tmpFile)
+	result, err := c.ImportAssets(context.Background(), "org1", tmpFile)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -180,13 +180,13 @@ func TestGetImportStatus(t *testing.T) {
 		if r.Method != http.MethodGet {
 			t.Errorf("expected GET, got %s", r.Method)
 		}
-		if r.URL.Path != "/assets/import/imp1" {
-			t.Errorf("expected path /assets/import/imp1, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/assets/import/imp1" {
+			t.Errorf("expected path /organizations/org1/assets/import/imp1, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{"status": "complete"})
 	})
 
-	result, err := c.GetImportStatus(context.Background(), "imp1")
+	result, err := c.GetImportStatus(context.Background(), "org1", "imp1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -203,8 +203,8 @@ func TestUploadAssetScreenshot(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/assets/a1/attachments" {
-			t.Errorf("expected path /assets/a1/attachments, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/assets/a1/attachments" {
+			t.Errorf("expected path /organizations/org1/assets/a1/attachments, got %s", r.URL.Path)
 		}
 		ct := r.Header.Get("Content-Type")
 		if !strings.HasPrefix(ct, "multipart/form-data") {
@@ -213,7 +213,7 @@ func TestUploadAssetScreenshot(t *testing.T) {
 		w.WriteHeader(http.StatusCreated)
 	})
 
-	err := c.UploadAssetScreenshot(context.Background(), "a1", tmpFile)
+	err := c.UploadAssetScreenshot(context.Background(), "org1", "a1", tmpFile)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -224,8 +224,8 @@ func TestListAssetPorts(t *testing.T) {
 		if r.Method != http.MethodGet {
 			t.Errorf("expected GET, got %s", r.Method)
 		}
-		if r.URL.Path != "/assets/a1/ports" {
-			t.Errorf("expected path /assets/a1/ports, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/assets/a1/ports" {
+			t.Errorf("expected path /organizations/org1/assets/a1/ports, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"data": []Port{
@@ -234,7 +234,7 @@ func TestListAssetPorts(t *testing.T) {
 		})
 	})
 
-	ports, err := c.ListAssetPorts(context.Background(), "a1", PageParams{Number: 1, Size: 10})
+	ports, err := c.ListAssetPorts(context.Background(), "org1", "a1", PageParams{Number: 1, Size: 10})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -251,8 +251,8 @@ func TestCreateAssetPort(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/assets/a1/ports" {
-			t.Errorf("expected path /assets/a1/ports, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/assets/a1/ports" {
+			t.Errorf("expected path /organizations/org1/assets/a1/ports, got %s", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusCreated)
 		json.NewEncoder(w).Encode(map[string]interface{}{
@@ -260,7 +260,7 @@ func TestCreateAssetPort(t *testing.T) {
 		})
 	})
 
-	port, err := c.CreateAssetPort(context.Background(), "a1", CreatePortInput{Port: 80, Protocol: "tcp"})
+	port, err := c.CreateAssetPort(context.Background(), "org1", "a1", CreatePortInput{Port: 80, Protocol: "tcp"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -274,13 +274,13 @@ func TestDeleteAssetPort(t *testing.T) {
 		if r.Method != http.MethodDelete {
 			t.Errorf("expected DELETE, got %s", r.Method)
 		}
-		if r.URL.Path != "/assets/a1/ports/p1" {
-			t.Errorf("expected path /assets/a1/ports/p1, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/assets/a1/ports/p1" {
+			t.Errorf("expected path /organizations/org1/assets/a1/ports/p1, got %s", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := c.DeleteAssetPort(context.Background(), "a1", "p1")
+	err := c.DeleteAssetPort(context.Background(), "org1", "a1", "p1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -291,13 +291,13 @@ func TestGetReachabilityStatus(t *testing.T) {
 		if r.Method != http.MethodGet {
 			t.Errorf("expected GET, got %s", r.Method)
 		}
-		if r.URL.Path != "/assets/a1/reachability_status" {
-			t.Errorf("expected path /assets/a1/reachability_status, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/assets/a1/reachability_status" {
+			t.Errorf("expected path /organizations/org1/assets/a1/reachability_status, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{"reachable": true})
 	})
 
-	result, err := c.GetReachabilityStatus(context.Background(), "a1")
+	result, err := c.GetReachabilityStatus(context.Background(), "org1", "a1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -311,13 +311,13 @@ func TestCheckReachability(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/assets/a1/check_reachability" {
-			t.Errorf("expected path /assets/a1/check_reachability, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/assets/a1/check_reachability" {
+			t.Errorf("expected path /organizations/org1/assets/a1/check_reachability, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{"status": "checking"})
 	})
 
-	result, err := c.CheckReachability(context.Background(), "a1")
+	result, err := c.CheckReachability(context.Background(), "org1", "a1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -331,15 +331,15 @@ func TestGetScannerConfig(t *testing.T) {
 		if r.Method != http.MethodGet {
 			t.Errorf("expected GET, got %s", r.Method)
 		}
-		if r.URL.Path != "/assets/a1/scanner_configuration" {
-			t.Errorf("expected path /assets/a1/scanner_configuration, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/assets/a1/scanner_configuration" {
+			t.Errorf("expected path /organizations/org1/assets/a1/scanner_configuration, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"data": ScannerConfiguration{Enabled: true},
 		})
 	})
 
-	cfg, err := c.GetScannerConfig(context.Background(), "a1")
+	cfg, err := c.GetScannerConfig(context.Background(), "org1", "a1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -353,15 +353,15 @@ func TestUpdateScannerConfig(t *testing.T) {
 		if r.Method != http.MethodPut {
 			t.Errorf("expected PUT, got %s", r.Method)
 		}
-		if r.URL.Path != "/assets/a1/scanner_configuration" {
-			t.Errorf("expected path /assets/a1/scanner_configuration, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/assets/a1/scanner_configuration" {
+			t.Errorf("expected path /organizations/org1/assets/a1/scanner_configuration, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"data": ScannerConfiguration{Enabled: false},
 		})
 	})
 
-	cfg, err := c.UpdateScannerConfig(context.Background(), "a1", ScannerConfiguration{Enabled: false})
+	cfg, err := c.UpdateScannerConfig(context.Background(), "org1", "a1", ScannerConfiguration{Enabled: false})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -375,13 +375,13 @@ func TestAddAssetScope(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/assets/scopes" {
-			t.Errorf("expected path /assets/scopes, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/assets/scopes" {
+			t.Errorf("expected path /organizations/org1/assets/scopes, got %s", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusCreated)
 	})
 
-	err := c.AddAssetScope(context.Background(), AssetScope{AssetID: "a1", ProgramID: "p1", Eligible: true})
+	err := c.AddAssetScope(context.Background(), "org1", AssetScope{AssetID: "a1", ProgramID: "p1", Eligible: true})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -392,13 +392,13 @@ func TestUpdateAssetScope(t *testing.T) {
 		if r.Method != http.MethodPut {
 			t.Errorf("expected PUT, got %s", r.Method)
 		}
-		if r.URL.Path != "/assets/a1/scopes" {
-			t.Errorf("expected path /assets/a1/scopes, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/assets/a1/scopes" {
+			t.Errorf("expected path /organizations/org1/assets/a1/scopes, got %s", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusOK)
 	})
 
-	err := c.UpdateAssetScope(context.Background(), "a1", AssetScope{Eligible: false})
+	err := c.UpdateAssetScope(context.Background(), "org1", "a1", AssetScope{Eligible: false})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -409,13 +409,13 @@ func TestArchiveAssetScopes(t *testing.T) {
 		if r.Method != http.MethodDelete {
 			t.Errorf("expected DELETE, got %s", r.Method)
 		}
-		if r.URL.Path != "/assets/a1/scopes" {
-			t.Errorf("expected path /assets/a1/scopes, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/assets/a1/scopes" {
+			t.Errorf("expected path /organizations/org1/assets/a1/scopes, got %s", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusNoContent)
 	})
 
-	err := c.ArchiveAssetScopes(context.Background(), "a1")
+	err := c.ArchiveAssetScopes(context.Background(), "org1", "a1")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -426,8 +426,8 @@ func TestListAssetTags(t *testing.T) {
 		if r.Method != http.MethodGet {
 			t.Errorf("expected GET, got %s", r.Method)
 		}
-		if r.URL.Path != "/asset_tags" {
-			t.Errorf("expected path /asset_tags, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/asset_tags" {
+			t.Errorf("expected path /organizations/org1/asset_tags, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"data": []AssetTag{
@@ -436,7 +436,7 @@ func TestListAssetTags(t *testing.T) {
 		})
 	})
 
-	tags, err := c.ListAssetTags(context.Background(), PageParams{Number: 1, Size: 10})
+	tags, err := c.ListAssetTags(context.Background(), "org1", PageParams{Number: 1, Size: 10})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -453,8 +453,8 @@ func TestCreateAssetTag(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/asset_tags" {
-			t.Errorf("expected path /asset_tags, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/asset_tags" {
+			t.Errorf("expected path /organizations/org1/asset_tags, got %s", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusCreated)
 		json.NewEncoder(w).Encode(map[string]interface{}{
@@ -462,7 +462,7 @@ func TestCreateAssetTag(t *testing.T) {
 		})
 	})
 
-	tag, err := c.CreateAssetTag(context.Background(), AssetTag{Attributes: AssetTagAttributes{Name: "new-tag"}})
+	tag, err := c.CreateAssetTag(context.Background(), "org1", AssetTag{Attributes: AssetTagAttributes{Name: "new-tag"}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -476,8 +476,8 @@ func TestListAssetTagCategories(t *testing.T) {
 		if r.Method != http.MethodGet {
 			t.Errorf("expected GET, got %s", r.Method)
 		}
-		if r.URL.Path != "/asset_tag_categories" {
-			t.Errorf("expected path /asset_tag_categories, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/asset_tag_categories" {
+			t.Errorf("expected path /organizations/org1/asset_tag_categories, got %s", r.URL.Path)
 		}
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"data": []AssetTagCategory{
@@ -486,7 +486,7 @@ func TestListAssetTagCategories(t *testing.T) {
 		})
 	})
 
-	cats, err := c.ListAssetTagCategories(context.Background(), PageParams{Number: 1, Size: 10})
+	cats, err := c.ListAssetTagCategories(context.Background(), "org1", PageParams{Number: 1, Size: 10})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -500,8 +500,8 @@ func TestCreateAssetTagCategory(t *testing.T) {
 		if r.Method != http.MethodPost {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
-		if r.URL.Path != "/asset_tag_categories" {
-			t.Errorf("expected path /asset_tag_categories, got %s", r.URL.Path)
+		if r.URL.Path != "/organizations/org1/asset_tag_categories" {
+			t.Errorf("expected path /organizations/org1/asset_tag_categories, got %s", r.URL.Path)
 		}
 		w.WriteHeader(http.StatusCreated)
 		json.NewEncoder(w).Encode(map[string]interface{}{
@@ -509,7 +509,7 @@ func TestCreateAssetTagCategory(t *testing.T) {
 		})
 	})
 
-	cat, err := c.CreateAssetTagCategory(context.Background(), AssetTagCategory{Attributes: AssetTagCategoryAttributes{Name: "new-cat"}})
+	cat, err := c.CreateAssetTagCategory(context.Background(), "org1", AssetTagCategory{Attributes: AssetTagCategoryAttributes{Name: "new-cat"}})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -524,7 +524,7 @@ func TestListAssetsAPIError(t *testing.T) {
 		json.NewEncoder(w).Encode(map[string]string{"message": "unauthorized"})
 	})
 
-	_, err := c.ListAssets(context.Background(), PageParams{})
+	_, err := c.ListAssets(context.Background(), "org1", PageParams{})
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -539,7 +539,7 @@ func TestListAssetsAPIError(t *testing.T) {
 
 func TestImportAssetsFileNotFound(t *testing.T) {
 	c := NewClient("id", "tok")
-	_, err := c.ImportAssets(context.Background(), "/nonexistent/file.csv")
+	_, err := c.ImportAssets(context.Background(), "org1", "/nonexistent/file.csv")
 	if err == nil {
 		t.Fatal("expected error for missing file")
 	}
@@ -547,7 +547,7 @@ func TestImportAssetsFileNotFound(t *testing.T) {
 
 func TestUploadAssetScreenshotFileNotFound(t *testing.T) {
 	c := NewClient("id", "tok")
-	err := c.UploadAssetScreenshot(context.Background(), "a1", "/nonexistent/file.png")
+	err := c.UploadAssetScreenshot(context.Background(), "org1", "a1", "/nonexistent/file.png")
 	if err == nil {
 		t.Fatal("expected error for missing file")
 	}

--- a/internal/cmd/assets.go
+++ b/internal/cmd/assets.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 
 	hackeronecli "github.com/scottbrown/hackerone-cli"
@@ -8,29 +9,39 @@ import (
 )
 
 func NewAssetsCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+	var orgID string
+
 	assetsCmd := &cobra.Command{
 		Use:   "assets",
 		Short: "Manage assets",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if orgID == "" {
+				return fmt.Errorf("--org is required for asset commands")
+			}
+			return nil
+		},
 	}
 
-	assetsCmd.AddCommand(newAssetsListCmd(clientFactory))
-	assetsCmd.AddCommand(newAssetsGetCmd(clientFactory))
-	assetsCmd.AddCommand(newAssetsCreateCmd(clientFactory))
-	assetsCmd.AddCommand(newAssetsUpdateCmd(clientFactory))
-	assetsCmd.AddCommand(newAssetsArchiveCmd(clientFactory))
-	assetsCmd.AddCommand(newAssetsImportCmd(clientFactory))
-	assetsCmd.AddCommand(newAssetsImportStatusCmd(clientFactory))
-	assetsCmd.AddCommand(newAssetsScreenshotCmd(clientFactory))
-	assetsCmd.AddCommand(newAssetsPortsCmd(clientFactory))
-	assetsCmd.AddCommand(newAssetsReachabilityCmd(clientFactory))
-	assetsCmd.AddCommand(newAssetsScannerCmd(clientFactory))
-	assetsCmd.AddCommand(newAssetsScopesCmd(clientFactory))
-	assetsCmd.AddCommand(newAssetsTagsCmd(clientFactory))
+	assetsCmd.PersistentFlags().StringVar(&orgID, "org", "", "Organization ID (required)")
+
+	assetsCmd.AddCommand(newAssetsListCmd(clientFactory, &orgID))
+	assetsCmd.AddCommand(newAssetsGetCmd(clientFactory, &orgID))
+	assetsCmd.AddCommand(newAssetsCreateCmd(clientFactory, &orgID))
+	assetsCmd.AddCommand(newAssetsUpdateCmd(clientFactory, &orgID))
+	assetsCmd.AddCommand(newAssetsArchiveCmd(clientFactory, &orgID))
+	assetsCmd.AddCommand(newAssetsImportCmd(clientFactory, &orgID))
+	assetsCmd.AddCommand(newAssetsImportStatusCmd(clientFactory, &orgID))
+	assetsCmd.AddCommand(newAssetsScreenshotCmd(clientFactory, &orgID))
+	assetsCmd.AddCommand(newAssetsPortsCmd(clientFactory, &orgID))
+	assetsCmd.AddCommand(newAssetsReachabilityCmd(clientFactory, &orgID))
+	assetsCmd.AddCommand(newAssetsScannerCmd(clientFactory, &orgID))
+	assetsCmd.AddCommand(newAssetsScopesCmd(clientFactory, &orgID))
+	assetsCmd.AddCommand(newAssetsTagsCmd(clientFactory, &orgID))
 
 	return assetsCmd
 }
 
-func newAssetsListCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsListCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	var page, pageSize int
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -41,11 +52,11 @@ func newAssetsListCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra
 			if err != nil {
 				return err
 			}
-			assets, err := client.ListAssets(cmd.Context(), hackeronecli.PageParams{Number: page, Size: pageSize})
+			assets, err := client.ListAssets(cmd.Context(), *orgID, hackeronecli.PageParams{Number: page, Size: pageSize})
 			if err != nil {
 				return err
 			}
-			return writeOutput(cmd,assets)
+			return writeOutput(cmd, assets)
 		},
 	}
 	cmd.Flags().IntVar(&page, "page", 0, "Page number")
@@ -53,7 +64,7 @@ func newAssetsListCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra
 	return cmd
 }
 
-func newAssetsGetCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsGetCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "get <id>",
 		Short: "Get an asset by ID",
@@ -63,16 +74,16 @@ func newAssetsGetCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.
 			if err != nil {
 				return err
 			}
-			asset, err := client.GetAsset(cmd.Context(), args[0])
+			asset, err := client.GetAsset(cmd.Context(), *orgID, args[0])
 			if err != nil {
 				return err
 			}
-			return writeOutput(cmd,asset)
+			return writeOutput(cmd, asset)
 		},
 	}
 }
 
-func newAssetsCreateCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsCreateCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	var input hackeronecli.CreateAssetInput
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -83,11 +94,11 @@ func newAssetsCreateCmd(clientFactory func() (*hackeronecli.Client, error)) *cob
 			if err != nil {
 				return err
 			}
-			asset, err := client.CreateAsset(cmd.Context(), input)
+			asset, err := client.CreateAsset(cmd.Context(), *orgID, input)
 			if err != nil {
 				return err
 			}
-			return writeOutput(cmd,asset)
+			return writeOutput(cmd, asset)
 		},
 	}
 	cmd.Flags().StringVar(&input.AssetType, "type", "", "Asset type")
@@ -98,7 +109,7 @@ func newAssetsCreateCmd(clientFactory func() (*hackeronecli.Client, error)) *cob
 	return cmd
 }
 
-func newAssetsUpdateCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsUpdateCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	var input hackeronecli.UpdateAssetInput
 	cmd := &cobra.Command{
 		Use:   "update <id>",
@@ -109,11 +120,11 @@ func newAssetsUpdateCmd(clientFactory func() (*hackeronecli.Client, error)) *cob
 			if err != nil {
 				return err
 			}
-			asset, err := client.UpdateAsset(cmd.Context(), args[0], input)
+			asset, err := client.UpdateAsset(cmd.Context(), *orgID, args[0], input)
 			if err != nil {
 				return err
 			}
-			return writeOutput(cmd,asset)
+			return writeOutput(cmd, asset)
 		},
 	}
 	cmd.Flags().StringVar(&input.AssetType, "type", "", "Asset type")
@@ -124,7 +135,7 @@ func newAssetsUpdateCmd(clientFactory func() (*hackeronecli.Client, error)) *cob
 	return cmd
 }
 
-func newAssetsArchiveCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsArchiveCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	var ids string
 	cmd := &cobra.Command{
 		Use:   "archive",
@@ -136,7 +147,7 @@ func newAssetsArchiveCmd(clientFactory func() (*hackeronecli.Client, error)) *co
 				return err
 			}
 			idList := strings.Split(ids, ",")
-			if err := client.ArchiveAssets(cmd.Context(), idList); err != nil {
+			if err := client.ArchiveAssets(cmd.Context(), *orgID, idList); err != nil {
 				return err
 			}
 			return writeMessage(cmd, "Assets archived successfully")
@@ -146,7 +157,7 @@ func newAssetsArchiveCmd(clientFactory func() (*hackeronecli.Client, error)) *co
 	return cmd
 }
 
-func newAssetsImportCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsImportCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "import <file>",
 		Short: "Import assets from a CSV file",
@@ -156,16 +167,16 @@ func newAssetsImportCmd(clientFactory func() (*hackeronecli.Client, error)) *cob
 			if err != nil {
 				return err
 			}
-			result, err := client.ImportAssets(cmd.Context(), args[0])
+			result, err := client.ImportAssets(cmd.Context(), *orgID, args[0])
 			if err != nil {
 				return err
 			}
-			return writeOutput(cmd,result)
+			return writeOutput(cmd, result)
 		},
 	}
 }
 
-func newAssetsImportStatusCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsImportStatusCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "import-status <id>",
 		Short: "Get the status of an asset import",
@@ -175,16 +186,16 @@ func newAssetsImportStatusCmd(clientFactory func() (*hackeronecli.Client, error)
 			if err != nil {
 				return err
 			}
-			result, err := client.GetImportStatus(cmd.Context(), args[0])
+			result, err := client.GetImportStatus(cmd.Context(), *orgID, args[0])
 			if err != nil {
 				return err
 			}
-			return writeOutput(cmd,result)
+			return writeOutput(cmd, result)
 		},
 	}
 }
 
-func newAssetsScreenshotCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsScreenshotCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "screenshot <id> <file>",
 		Short: "Upload a screenshot for an asset",
@@ -194,7 +205,7 @@ func newAssetsScreenshotCmd(clientFactory func() (*hackeronecli.Client, error)) 
 			if err != nil {
 				return err
 			}
-			if err := client.UploadAssetScreenshot(cmd.Context(), args[0], args[1]); err != nil {
+			if err := client.UploadAssetScreenshot(cmd.Context(), *orgID, args[0], args[1]); err != nil {
 				return err
 			}
 			return writeMessage(cmd, "Screenshot uploaded successfully")
@@ -202,20 +213,20 @@ func newAssetsScreenshotCmd(clientFactory func() (*hackeronecli.Client, error)) 
 	}
 }
 
-func newAssetsPortsCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsPortsCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	portsCmd := &cobra.Command{
 		Use:   "ports",
 		Short: "Manage asset ports",
 	}
 
-	portsCmd.AddCommand(newAssetsPortsListCmd(clientFactory))
-	portsCmd.AddCommand(newAssetsPortsCreateCmd(clientFactory))
-	portsCmd.AddCommand(newAssetsPortsDeleteCmd(clientFactory))
+	portsCmd.AddCommand(newAssetsPortsListCmd(clientFactory, orgID))
+	portsCmd.AddCommand(newAssetsPortsCreateCmd(clientFactory, orgID))
+	portsCmd.AddCommand(newAssetsPortsDeleteCmd(clientFactory, orgID))
 
 	return portsCmd
 }
 
-func newAssetsPortsListCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsPortsListCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	var page, pageSize int
 	cmd := &cobra.Command{
 		Use:   "list <asset-id>",
@@ -226,11 +237,11 @@ func newAssetsPortsListCmd(clientFactory func() (*hackeronecli.Client, error)) *
 			if err != nil {
 				return err
 			}
-			ports, err := client.ListAssetPorts(cmd.Context(), args[0], hackeronecli.PageParams{Number: page, Size: pageSize})
+			ports, err := client.ListAssetPorts(cmd.Context(), *orgID, args[0], hackeronecli.PageParams{Number: page, Size: pageSize})
 			if err != nil {
 				return err
 			}
-			return writeOutput(cmd,ports)
+			return writeOutput(cmd, ports)
 		},
 	}
 	cmd.Flags().IntVar(&page, "page", 0, "Page number")
@@ -238,7 +249,7 @@ func newAssetsPortsListCmd(clientFactory func() (*hackeronecli.Client, error)) *
 	return cmd
 }
 
-func newAssetsPortsCreateCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsPortsCreateCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	var input hackeronecli.CreatePortInput
 	cmd := &cobra.Command{
 		Use:   "create <asset-id>",
@@ -249,11 +260,11 @@ func newAssetsPortsCreateCmd(clientFactory func() (*hackeronecli.Client, error))
 			if err != nil {
 				return err
 			}
-			port, err := client.CreateAssetPort(cmd.Context(), args[0], input)
+			port, err := client.CreateAssetPort(cmd.Context(), *orgID, args[0], input)
 			if err != nil {
 				return err
 			}
-			return writeOutput(cmd,port)
+			return writeOutput(cmd, port)
 		},
 	}
 	cmd.Flags().IntVar(&input.Port, "port", 0, "Port number")
@@ -262,7 +273,7 @@ func newAssetsPortsCreateCmd(clientFactory func() (*hackeronecli.Client, error))
 	return cmd
 }
 
-func newAssetsPortsDeleteCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsPortsDeleteCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "delete <asset-id> <port-id>",
 		Short: "Delete a port from an asset",
@@ -272,7 +283,7 @@ func newAssetsPortsDeleteCmd(clientFactory func() (*hackeronecli.Client, error))
 			if err != nil {
 				return err
 			}
-			if err := client.DeleteAssetPort(cmd.Context(), args[0], args[1]); err != nil {
+			if err := client.DeleteAssetPort(cmd.Context(), *orgID, args[0], args[1]); err != nil {
 				return err
 			}
 			return writeMessage(cmd, "Port deleted successfully")
@@ -280,19 +291,19 @@ func newAssetsPortsDeleteCmd(clientFactory func() (*hackeronecli.Client, error))
 	}
 }
 
-func newAssetsReachabilityCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsReachabilityCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	reachCmd := &cobra.Command{
 		Use:   "reachability",
 		Short: "Asset reachability operations",
 	}
 
-	reachCmd.AddCommand(newAssetsReachabilityStatusCmd(clientFactory))
-	reachCmd.AddCommand(newAssetsReachabilityCheckCmd(clientFactory))
+	reachCmd.AddCommand(newAssetsReachabilityStatusCmd(clientFactory, orgID))
+	reachCmd.AddCommand(newAssetsReachabilityCheckCmd(clientFactory, orgID))
 
 	return reachCmd
 }
 
-func newAssetsReachabilityStatusCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsReachabilityStatusCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "status <asset-id>",
 		Short: "Get reachability status for an asset",
@@ -302,16 +313,16 @@ func newAssetsReachabilityStatusCmd(clientFactory func() (*hackeronecli.Client, 
 			if err != nil {
 				return err
 			}
-			result, err := client.GetReachabilityStatus(cmd.Context(), args[0])
+			result, err := client.GetReachabilityStatus(cmd.Context(), *orgID, args[0])
 			if err != nil {
 				return err
 			}
-			return writeOutput(cmd,result)
+			return writeOutput(cmd, result)
 		},
 	}
 }
 
-func newAssetsReachabilityCheckCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsReachabilityCheckCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "check <asset-id>",
 		Short: "Check reachability for an asset",
@@ -321,28 +332,28 @@ func newAssetsReachabilityCheckCmd(clientFactory func() (*hackeronecli.Client, e
 			if err != nil {
 				return err
 			}
-			result, err := client.CheckReachability(cmd.Context(), args[0])
+			result, err := client.CheckReachability(cmd.Context(), *orgID, args[0])
 			if err != nil {
 				return err
 			}
-			return writeOutput(cmd,result)
+			return writeOutput(cmd, result)
 		},
 	}
 }
 
-func newAssetsScannerCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsScannerCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	scannerCmd := &cobra.Command{
 		Use:   "scanner",
 		Short: "Scanner configuration operations",
 	}
 
-	scannerCmd.AddCommand(newAssetsScannerGetCmd(clientFactory))
-	scannerCmd.AddCommand(newAssetsScannerUpdateCmd(clientFactory))
+	scannerCmd.AddCommand(newAssetsScannerGetCmd(clientFactory, orgID))
+	scannerCmd.AddCommand(newAssetsScannerUpdateCmd(clientFactory, orgID))
 
 	return scannerCmd
 }
 
-func newAssetsScannerGetCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsScannerGetCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "get <asset-id>",
 		Short: "Get scanner configuration for an asset",
@@ -352,16 +363,16 @@ func newAssetsScannerGetCmd(clientFactory func() (*hackeronecli.Client, error)) 
 			if err != nil {
 				return err
 			}
-			cfg, err := client.GetScannerConfig(cmd.Context(), args[0])
+			cfg, err := client.GetScannerConfig(cmd.Context(), *orgID, args[0])
 			if err != nil {
 				return err
 			}
-			return writeOutput(cmd,cfg)
+			return writeOutput(cmd, cfg)
 		},
 	}
 }
 
-func newAssetsScannerUpdateCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsScannerUpdateCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	var enabled bool
 	cmd := &cobra.Command{
 		Use:   "update <asset-id>",
@@ -372,31 +383,31 @@ func newAssetsScannerUpdateCmd(clientFactory func() (*hackeronecli.Client, error
 			if err != nil {
 				return err
 			}
-			cfg, err := client.UpdateScannerConfig(cmd.Context(), args[0], hackeronecli.ScannerConfiguration{Enabled: enabled})
+			cfg, err := client.UpdateScannerConfig(cmd.Context(), *orgID, args[0], hackeronecli.ScannerConfiguration{Enabled: enabled})
 			if err != nil {
 				return err
 			}
-			return writeOutput(cmd,cfg)
+			return writeOutput(cmd, cfg)
 		},
 	}
 	cmd.Flags().BoolVar(&enabled, "enabled", false, "Enable or disable the scanner")
 	return cmd
 }
 
-func newAssetsScopesCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsScopesCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	scopesCmd := &cobra.Command{
 		Use:   "scopes",
 		Short: "Manage asset scopes",
 	}
 
-	scopesCmd.AddCommand(newAssetsScopesAddCmd(clientFactory))
-	scopesCmd.AddCommand(newAssetsScopesUpdateCmd(clientFactory))
-	scopesCmd.AddCommand(newAssetsScopesArchiveCmd(clientFactory))
+	scopesCmd.AddCommand(newAssetsScopesAddCmd(clientFactory, orgID))
+	scopesCmd.AddCommand(newAssetsScopesUpdateCmd(clientFactory, orgID))
+	scopesCmd.AddCommand(newAssetsScopesArchiveCmd(clientFactory, orgID))
 
 	return scopesCmd
 }
 
-func newAssetsScopesAddCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsScopesAddCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	var input hackeronecli.AssetScope
 	cmd := &cobra.Command{
 		Use:   "add",
@@ -407,7 +418,7 @@ func newAssetsScopesAddCmd(clientFactory func() (*hackeronecli.Client, error)) *
 			if err != nil {
 				return err
 			}
-			if err := client.AddAssetScope(cmd.Context(), input); err != nil {
+			if err := client.AddAssetScope(cmd.Context(), *orgID, input); err != nil {
 				return err
 			}
 			return writeMessage(cmd, "Asset scope added successfully")
@@ -419,7 +430,7 @@ func newAssetsScopesAddCmd(clientFactory func() (*hackeronecli.Client, error)) *
 	return cmd
 }
 
-func newAssetsScopesUpdateCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsScopesUpdateCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	var input hackeronecli.AssetScope
 	cmd := &cobra.Command{
 		Use:   "update <asset-id>",
@@ -430,7 +441,7 @@ func newAssetsScopesUpdateCmd(clientFactory func() (*hackeronecli.Client, error)
 			if err != nil {
 				return err
 			}
-			if err := client.UpdateAssetScope(cmd.Context(), args[0], input); err != nil {
+			if err := client.UpdateAssetScope(cmd.Context(), *orgID, args[0], input); err != nil {
 				return err
 			}
 			return writeMessage(cmd, "Asset scope updated successfully")
@@ -441,7 +452,7 @@ func newAssetsScopesUpdateCmd(clientFactory func() (*hackeronecli.Client, error)
 	return cmd
 }
 
-func newAssetsScopesArchiveCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsScopesArchiveCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "archive <asset-id>",
 		Short: "Archive scopes for an asset",
@@ -451,7 +462,7 @@ func newAssetsScopesArchiveCmd(clientFactory func() (*hackeronecli.Client, error
 			if err != nil {
 				return err
 			}
-			if err := client.ArchiveAssetScopes(cmd.Context(), args[0]); err != nil {
+			if err := client.ArchiveAssetScopes(cmd.Context(), *orgID, args[0]); err != nil {
 				return err
 			}
 			return writeMessage(cmd, "Asset scopes archived successfully")
@@ -459,21 +470,21 @@ func newAssetsScopesArchiveCmd(clientFactory func() (*hackeronecli.Client, error
 	}
 }
 
-func newAssetsTagsCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsTagsCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	tagsCmd := &cobra.Command{
 		Use:   "tags",
 		Short: "Manage asset tags",
 	}
 
-	tagsCmd.AddCommand(newAssetsTagsListCmd(clientFactory))
-	tagsCmd.AddCommand(newAssetsTagsCreateCmd(clientFactory))
-	tagsCmd.AddCommand(newAssetsTagsCategoriesCmd(clientFactory))
-	tagsCmd.AddCommand(newAssetsTagsCreateCategoryCmd(clientFactory))
+	tagsCmd.AddCommand(newAssetsTagsListCmd(clientFactory, orgID))
+	tagsCmd.AddCommand(newAssetsTagsCreateCmd(clientFactory, orgID))
+	tagsCmd.AddCommand(newAssetsTagsCategoriesCmd(clientFactory, orgID))
+	tagsCmd.AddCommand(newAssetsTagsCreateCategoryCmd(clientFactory, orgID))
 
 	return tagsCmd
 }
 
-func newAssetsTagsListCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsTagsListCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	var page, pageSize int
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -484,11 +495,11 @@ func newAssetsTagsListCmd(clientFactory func() (*hackeronecli.Client, error)) *c
 			if err != nil {
 				return err
 			}
-			tags, err := client.ListAssetTags(cmd.Context(), hackeronecli.PageParams{Number: page, Size: pageSize})
+			tags, err := client.ListAssetTags(cmd.Context(), *orgID, hackeronecli.PageParams{Number: page, Size: pageSize})
 			if err != nil {
 				return err
 			}
-			return writeOutput(cmd,tags)
+			return writeOutput(cmd, tags)
 		},
 	}
 	cmd.Flags().IntVar(&page, "page", 0, "Page number")
@@ -496,7 +507,7 @@ func newAssetsTagsListCmd(clientFactory func() (*hackeronecli.Client, error)) *c
 	return cmd
 }
 
-func newAssetsTagsCreateCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsTagsCreateCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	var name, categoryID string
 	cmd := &cobra.Command{
 		Use:   "create",
@@ -507,13 +518,13 @@ func newAssetsTagsCreateCmd(clientFactory func() (*hackeronecli.Client, error)) 
 			if err != nil {
 				return err
 			}
-			tag, err := client.CreateAssetTag(cmd.Context(), hackeronecli.AssetTag{
+			tag, err := client.CreateAssetTag(cmd.Context(), *orgID, hackeronecli.AssetTag{
 				Attributes: hackeronecli.AssetTagAttributes{Name: name, CategoryID: categoryID},
 			})
 			if err != nil {
 				return err
 			}
-			return writeOutput(cmd,tag)
+			return writeOutput(cmd, tag)
 		},
 	}
 	cmd.Flags().StringVar(&name, "name", "", "Tag name")
@@ -521,7 +532,7 @@ func newAssetsTagsCreateCmd(clientFactory func() (*hackeronecli.Client, error)) 
 	return cmd
 }
 
-func newAssetsTagsCategoriesCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsTagsCategoriesCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	var page, pageSize int
 	cmd := &cobra.Command{
 		Use:   "categories",
@@ -532,11 +543,11 @@ func newAssetsTagsCategoriesCmd(clientFactory func() (*hackeronecli.Client, erro
 			if err != nil {
 				return err
 			}
-			cats, err := client.ListAssetTagCategories(cmd.Context(), hackeronecli.PageParams{Number: page, Size: pageSize})
+			cats, err := client.ListAssetTagCategories(cmd.Context(), *orgID, hackeronecli.PageParams{Number: page, Size: pageSize})
 			if err != nil {
 				return err
 			}
-			return writeOutput(cmd,cats)
+			return writeOutput(cmd, cats)
 		},
 	}
 	cmd.Flags().IntVar(&page, "page", 0, "Page number")
@@ -544,7 +555,7 @@ func newAssetsTagsCategoriesCmd(clientFactory func() (*hackeronecli.Client, erro
 	return cmd
 }
 
-func newAssetsTagsCreateCategoryCmd(clientFactory func() (*hackeronecli.Client, error)) *cobra.Command {
+func newAssetsTagsCreateCategoryCmd(clientFactory func() (*hackeronecli.Client, error), orgID *string) *cobra.Command {
 	var name string
 	cmd := &cobra.Command{
 		Use:   "create-category",
@@ -555,13 +566,13 @@ func newAssetsTagsCreateCategoryCmd(clientFactory func() (*hackeronecli.Client, 
 			if err != nil {
 				return err
 			}
-			cat, err := client.CreateAssetTagCategory(cmd.Context(), hackeronecli.AssetTagCategory{
+			cat, err := client.CreateAssetTagCategory(cmd.Context(), *orgID, hackeronecli.AssetTagCategory{
 				Attributes: hackeronecli.AssetTagCategoryAttributes{Name: name},
 			})
 			if err != nil {
 				return err
 			}
-			return writeOutput(cmd,cat)
+			return writeOutput(cmd, cat)
 		},
 	}
 	cmd.Flags().StringVar(&name, "name", "", "Category name")


### PR DESCRIPTION
## Summary
- All asset API endpoints now use `/organizations/{org_id}/assets/...` paths instead of `/assets/...`
- Asset tags use `/organizations/{org_id}/asset_tags` and `/organizations/{org_id}/asset_tag_categories`
- Every client method in `assets.go` now takes an `orgID` parameter
- The CLI `assets` command has a required `--org` persistent flag that applies to all subcommands
- Usage: `h1 assets --org 38871 list`

## Test plan
- [x] `go test ./...` passes
- [x] `go build ./...` compiles cleanly
- [x] `h1 assets --org 38871 list` returns 16 assets from live API (was 404)
- [x] `h1 assets list` (without --org) returns clear error message

Generated with [Claude Code](https://claude.com/claude-code)