### PR TITLE
Fix release asset upload race between build and macos-pkg jobs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v3
         with:
+          draft: true
           files: |
             bom.json
             .dist/*.tar.gz
@@ -37,6 +38,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
   macos-pkg:
+    needs: build
     runs-on: macos-latest
     permissions:
       contents: write
@@ -110,6 +112,18 @@ jobs:
       - name: Upload macOS package to Release
         uses: softprops/action-gh-release@v3
         with:
+          draft: true
           files: .dist/*.pkg
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    needs: [build, macos-pkg]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Publish Release
+        run: gh release edit "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --draft=false
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

PR #10 added a `macos-pkg` job that calls `softprops/action-gh-release`
against the same tag as the existing `build` job. The two ran in
parallel; whichever finished first **published** the release, and
GitHub immutable releases lock assets on publish. In the `v1.0.9-rc1`
test run the faster `macos-pkg` job published first, so the `build` job
failed to upload its tarballs and SBOM:

> Cannot upload asset h1_..._windows_amd64.tar.gz to an immutable release.

The release ended up published with only the `.pkg` attached.

## Fix

- `build` creates the release as a **draft** (`draft: true`).
- `macos-pkg` now `needs: build` and also uploads to the draft.
- A new `publish` job (`needs: [build, macos-pkg]`) flips the release
  live with `gh release edit --draft=false` once every asset is
  attached.

Drafts are mutable, so all assets land before the single publish step
locks immutability.

## Validation

Signing itself was already proven green by the `v1.0.9-rc1` run — the
`macos-pkg` job passed. This PR only reorders release publication.
Recommend another throwaway RC tag after merge to confirm all artifacts
(tarballs, SBOM, signed `.pkg`) land on one published release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)