### PR TITLE
Notarize macOS .pkg and sign + notarize darwin tarball binaries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,8 +20,10 @@ jobs:
         uses: arduino/setup-task@v2
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Compile all versions
-        run: task release VERSION=${GITHUB_REF_NAME}
+      - name: Compile linux and windows versions
+        run: |
+          mkdir -p .dist
+          task release-linux release-windows VERSION=${GITHUB_REF_NAME}
       - name: Generate SBOM
         uses: CycloneDX/gh-gomod-generate-sbom@v2
         with:
@@ -80,16 +82,21 @@ jobs:
             -A -t cert -f pkcs12 \
             -k "$KEYCHAIN_PATH"
           security list-keychain -d user -s "$KEYCHAIN_PATH"
-      - name: Sign macOS binary
+      - name: Sign macOS binaries
         env:
           MACOS_APP_CERT_IDENTITY: ${{ secrets.MACOS_APP_CERT_IDENTITY }}
         run: |
-          codesign \
-            --sign "$MACOS_APP_CERT_IDENTITY" \
-            --options runtime \
-            --timestamp \
-            --force \
-            .build/darwin-universal/h1
+          for bin in \
+            .build/darwin-universal/h1 \
+            .build/darwin-amd64/h1 \
+            .build/darwin-arm64/h1; do
+            codesign \
+              --sign "$MACOS_APP_CERT_IDENTITY" \
+              --options runtime \
+              --timestamp \
+              --force \
+              "$bin"
+          done
       - name: Build and sign macOS package
         env:
           MACOS_CERTIFICATE_IDENTITY: ${{ secrets.MACOS_CERTIFICATE_IDENTITY }}
@@ -106,14 +113,41 @@ jobs:
             --sign "$MACOS_CERTIFICATE_IDENTITY" \
             $RUNNER_TEMP/h1_unsigned.pkg \
             .dist/h1_${VERSION}_darwin.pkg
+      - name: Create signed macOS tarballs
+        run: |
+          VERSION=${GITHUB_REF_NAME}
+          tar cfz .dist/h1_${VERSION}_darwin_amd64.tar.gz -C .build/darwin-amd64 h1
+          tar cfz .dist/h1_${VERSION}_darwin_arm64.tar.gz -C .build/darwin-arm64 h1
+      - name: Notarize macOS artifacts
+        env:
+          MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+          MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+        run: |
+          VERSION=${GITHUB_REF_NAME}
+          KEY_PATH=$RUNNER_TEMP/notary_key.p8
+          echo "$MACOS_NOTARY_KEY" | base64 --decode > "$KEY_PATH"
+          mkdir "$RUNNER_TEMP/notarize"
+          cp .dist/h1_${VERSION}_darwin.pkg "$RUNNER_TEMP/notarize/"
+          cp .build/darwin-amd64/h1 "$RUNNER_TEMP/notarize/h1-darwin-amd64"
+          cp .build/darwin-arm64/h1 "$RUNNER_TEMP/notarize/h1-darwin-arm64"
+          ditto -c -k "$RUNNER_TEMP/notarize" "$RUNNER_TEMP/notarize.zip"
+          xcrun notarytool submit "$RUNNER_TEMP/notarize.zip" \
+            --key "$KEY_PATH" \
+            --key-id "$MACOS_NOTARY_KEY_ID" \
+            --issuer "$MACOS_NOTARY_ISSUER_ID" \
+            --wait
+          xcrun stapler staple .dist/h1_${VERSION}_darwin.pkg
       - name: Clean up keychain
         if: always()
         run: security delete-keychain $RUNNER_TEMP/signing.keychain-db
-      - name: Upload macOS package to Release
+      - name: Upload macOS artifacts to Release
         uses: softprops/action-gh-release@v3
         with:
           draft: true
-          files: .dist/*.pkg
+          files: |
+            .dist/*.pkg
+            .dist/*_darwin_*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ The binary is placed at `bin/h1`.
 go install github.com/scottbrown/hackerone-cli/cmd/h1@latest
 ```
 
+### macOS
+
+Each [release](https://github.com/scottbrown/hackerone-cli/releases) ships a
+signed and notarized macOS installer, `h1_<version>_darwin.pkg`, containing a
+universal (Intel + Apple Silicon) binary that installs to `/usr/local/bin`:
+
+```bash
+sudo installer -pkg h1_<version>_darwin.pkg -target /
+```
+
+Per-architecture tarballs (`h1_<version>_darwin_amd64.tar.gz`,
+`h1_<version>_darwin_arm64.tar.gz`) are also published; the binaries inside are
+signed with a Developer ID and notarized by Apple.
+
 ## Authentication
 
 The CLI uses HTTP Basic Auth with your HackerOne API credentials. Set these environment variables:


### PR DESCRIPTION
Closes #14.

## Problem

Verification of `v1.0.9` found that no macOS artifact was notarized, so
Gatekeeper blocks them on download. The darwin tarball binaries were also
only ad-hoc signed (`go build` output from the ubuntu job).

## Changes

- Darwin tarballs are now built on the **macOS runner**, not the ubuntu
  `build` job, so their per-arch binaries can be Developer ID signed.
  The `build` job now compiles only linux + windows.
- The `macos-pkg` job signs the universal **and** both per-arch binaries
  with the Developer ID Application identity + hardened runtime.
- New **Notarize** step submits the `.pkg` and both binaries to
  `notarytool` in one submission, then staples the ticket to the `.pkg`.
- README gains a macOS install section.

Apple does not support stapling a bare executable, so the tarball binaries
rely on Gatekeeper's online notarization check (the `.pkg` is fully stapled).

## New secrets required

Before this can run, add an App Store Connect API key as three repo secrets:

- `MACOS_NOTARY_KEY` — base64-encoded `.p8` private key
- `MACOS_NOTARY_KEY_ID` — the key ID
- `MACOS_NOTARY_ISSUER_ID` — the issuer ID

## Validation

CI cannot exercise the release workflow. After merging and adding the
secrets, cut a throwaway RC tag and verify with `spctl -a -t install`,
`xcrun stapler validate`, and `codesign --verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)