### PR TITLE
Add notarytool timeout and drop Node 20 actions from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,24 +17,23 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install Task
-        uses: arduino/setup-task@v2
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          go install github.com/go-task/task/v3/cmd/task@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - name: Compile linux and windows versions
         run: |
           mkdir -p .dist
           task release-linux release-windows VERSION=${GITHUB_REF_NAME}
       - name: Generate SBOM
-        uses: CycloneDX/gh-gomod-generate-sbom@v2
-        with:
-          version: v1
-          args: mod -licenses -json -output bom.json
+        run: |
+          go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest
+          task sbom
       - name: Create Release
         uses: softprops/action-gh-release@v3
         with:
           draft: true
           files: |
-            bom.json
+            .dist/bom.json
             .dist/*.tar.gz
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -52,9 +51,9 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install Task
-        uses: arduino/setup-task@v2
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        run: |
+          go install github.com/go-task/task/v3/cmd/task@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
       - name: Build macOS binaries
         run: |
           mkdir -p .build/darwin-amd64 .build/darwin-arm64
@@ -136,7 +135,8 @@ jobs:
             --key "$KEY_PATH" \
             --key-id "$MACOS_NOTARY_KEY_ID" \
             --issuer "$MACOS_NOTARY_ISSUER_ID" \
-            --wait
+            --wait \
+            --timeout 30m
           xcrun stapler staple .dist/h1_${VERSION}_darwin.pkg
       - name: Clean up keychain
         if: always()


### PR DESCRIPTION
## Notarization timeout

`xcrun notarytool submit --wait` had no timeout, so a stuck Apple notary
submission would hang the job until the 6-hour limit. Added `--timeout 30m`
so it fails fast and cleanly instead.

## Drop Node 20 actions (closes #13)

`arduino/setup-task` and `CycloneDX/gh-gomod-generate-sbom` were the two
actions flagged for the June 2026 Node 20 runtime removal. Neither has a
Node 24 release to bump to:

- `arduino/setup-task` — latest `v2.0.0`, still node20
- `CycloneDX/gh-gomod-generate-sbom` — latest `v2.0.0`, still node16

So instead of waiting on upstream, both are replaced with direct `go install`
calls — Go is already set up in the workflow:

- Task is installed via `go install github.com/go-task/task/v3/cmd/task`
- SBOM generation installs `cyclonedx-gomod` and reuses the existing
  `task sbom` target, which writes to `.dist/bom.json` (the release upload
  path is updated to match; the published asset is still named `bom.json`)

This removes the Node 20 dependency entirely. The remaining actions
(`actions/checkout@v6`, `actions/setup-go@v6`, `softprops/action-gh-release@v3`)
were not flagged.

## Validation

CI cannot exercise the release workflow; verify on the next RC tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)