### PR TITLE
Dump notary log on notarization failure

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,12 +131,28 @@ jobs:
           cp .build/darwin-amd64/h1 "$RUNNER_TEMP/notarize/h1-darwin-amd64"
           cp .build/darwin-arm64/h1 "$RUNNER_TEMP/notarize/h1-darwin-arm64"
           ditto -c -k "$RUNNER_TEMP/notarize" "$RUNNER_TEMP/notarize.zip"
-          xcrun notarytool submit "$RUNNER_TEMP/notarize.zip" \
+          SUBMISSION_ID=$(xcrun notarytool submit "$RUNNER_TEMP/notarize.zip" \
             --key "$KEY_PATH" \
             --key-id "$MACOS_NOTARY_KEY_ID" \
             --issuer "$MACOS_NOTARY_ISSUER_ID" \
-            --wait \
-            --timeout 30m
+            --output-format json | jq -r '.id')
+          echo "Notarization submission ID: $SUBMISSION_ID"
+          if ! xcrun notarytool wait "$SUBMISSION_ID" \
+            --key "$KEY_PATH" \
+            --key-id "$MACOS_NOTARY_KEY_ID" \
+            --issuer "$MACOS_NOTARY_ISSUER_ID" \
+            --timeout 30m; then
+            echo "::error::Notarization failed or timed out; fetching status and log:"
+            xcrun notarytool info "$SUBMISSION_ID" \
+              --key "$KEY_PATH" \
+              --key-id "$MACOS_NOTARY_KEY_ID" \
+              --issuer "$MACOS_NOTARY_ISSUER_ID" || true
+            xcrun notarytool log "$SUBMISSION_ID" \
+              --key "$KEY_PATH" \
+              --key-id "$MACOS_NOTARY_KEY_ID" \
+              --issuer "$MACOS_NOTARY_ISSUER_ID" || true
+            exit 1
+          fi
           xcrun stapler staple .dist/h1_${VERSION}_darwin.pkg
       - name: Clean up keychain
         if: always()


### PR DESCRIPTION
## Problem

Notarization was a single `notarytool submit --wait` call. When the
`v1.0.10-rc1` run stalled for 37 minutes and was cancelled, there was no
log to explain why — and a timeout or rejection would fail the job with no
diagnostic output.

## Change

The notarize step is split into two calls:

- `notarytool submit` (no `--wait`) — captures the submission ID from JSON
- `notarytool wait <id> --timeout 30m`

If `wait` fails for any reason — timeout or an `Invalid` verdict — the step
dumps `notarytool info` and `notarytool log` for that submission before
failing. The next failed run will capture Apple's actual reason in the run
output instead of leaving us guessing.

On success, behaviour is unchanged: the `.pkg` is stapled.

## Validation

CI cannot exercise the release workflow; verify on the next RC tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)