### PR TITLE
Allow Go toolchain auto-download for go install steps

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,8 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install Task
+        env:
+          GOTOOLCHAIN: auto
         run: |
           go install github.com/go-task/task/v3/cmd/task@latest
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
@@ -25,6 +27,8 @@ jobs:
           mkdir -p .dist
           task release-linux release-windows VERSION=${GITHUB_REF_NAME}
       - name: Generate SBOM
+        env:
+          GOTOOLCHAIN: auto
         run: |
           go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest
           task sbom
@@ -51,6 +55,8 @@ jobs:
         with:
           go-version-file: go.mod
       - name: Install Task
+        env:
+          GOTOOLCHAIN: auto
         run: |
           go install github.com/go-task/task/v3/cmd/task@latest
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
## Problem

PR #16 replaced the Node 20 actions with `go install`, but the release
workflow then failed on `v1.0.10-rc2` at the **Install Task** step:

```
github.com/go-task/task/v3@v3.51.1 requires go >= 1.25.10
(running go 1.25.0; GOTOOLCHAIN=local)
```

`actions/setup-go` pins Go to the `go.mod` version (1.25.0) and sets
`GOTOOLCHAIN=local`, which blocks toolchain auto-download. `task@latest`
needs a newer Go than that, so `go install` could not build it.

## Fix

Set `GOTOOLCHAIN=auto` on the three `go install` steps (both Install Task
steps and Generate SBOM). Go then fetches whatever toolchain the tool
requires. The project build is unaffected — it still compiles with the
`go.mod`-pinned toolchain.

## Validation

CI cannot exercise the release workflow; verify on the next RC tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)